### PR TITLE
Split frontend into routed pages with Leaflet map

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,11 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-leaflet": "^4.2.1",
+        "react-router-dom": "^7.9.3",
         "sass": "^1.93.2"
       },
       "devDependencies": {
@@ -1303,6 +1306,17 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.38.tgz",
@@ -1953,6 +1967,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2586,6 +2609,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2909,6 +2938,20 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2917,6 +2960,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.3.tgz",
+      "integrity": "sha512-4o2iWCFIwhI/eYAIL43+cjORXYn/aRQPgtFRRZb3VzoyQ5Uej0Bmqj7437L97N9NJW4wnicSwLOLS+yCXfAPgg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.3.tgz",
+      "integrity": "sha512-1QSbA0TGGFKTAc/aWjpfW/zoEukYfU4dc1dLkT/vvf54JoGMkW+fNA+3oyo2gWVW1GM7BxjJVHz5GnPJv40rvg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/readdirp": {
@@ -3022,6 +3103,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-leaflet": "^4.2.1",
+    "react-router-dom": "^7.9.3",
     "sass": "^1.93.2"
   },
   "devDependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,48 @@
-function App() {
+import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom'
+import PublicInfoPage from './pages/PublicInfoPage.jsx'
+import LoginPage from './pages/LoginPage.jsx'
+import RegisterPage from './pages/RegisterPage.jsx'
+import DashboardPage from './pages/DashboardPage.jsx'
+import OrganizerPanelPage from './pages/OrganizerPanelPage.jsx'
+import VolunteerPanelPage from './pages/VolunteerPanelPage.jsx'
+import MapPage from './pages/MapPage.jsx'
+
+const navigation = [
+  { to: '/', label: 'Start' },
+  { to: '/login', label: 'Log in' },
+  { to: '/register', label: 'Register' },
+  { to: '/dashboard', label: 'Dashboard' },
+  { to: '/organizer', label: 'Organizer' },
+  { to: '/volunteer', label: 'Volunteer' },
+  { to: '/map', label: 'Map' },
+]
+
+export default function App() {
   return (
-    <>
-      Hello world!
-    </>
+    <BrowserRouter>
+      <div className="app">
+        <header className="header">
+          <span className="brand">HackYeah 2025</span>
+          <nav className="nav">
+            {navigation.map((item) => (
+              <NavLink key={item.to} to={item.to} className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}>
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+        </header>
+        <main className="content">
+          <Routes>
+            <Route path="/" element={<PublicInfoPage />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/register" element={<RegisterPage />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/organizer" element={<OrganizerPanelPage />} />
+            <Route path="/volunteer" element={<VolunteerPanelPage />} />
+            <Route path="/map" element={<MapPage />} />
+          </Routes>
+        </main>
+      </div>
+    </BrowserRouter>
   )
 }
-
-export default App

--- a/frontend/src/main.scss
+++ b/frontend/src/main.scss
@@ -1,0 +1,171 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #1e293b, #0f172a 50%, #020617 100%);
+  color: #e2e8f0;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.5rem 2rem;
+  background-color: rgba(15, 23, 42, 0.8);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.brand {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.nav-link {
+  color: #cbd5f5;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.nav-link:hover {
+  background-color: rgba(99, 102, 241, 0.12);
+}
+
+.nav-link.active {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #f8fafc;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+}
+
+.page {
+  width: min(960px, 100%);
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  color: #f8fafc;
+}
+
+p {
+  margin: 0;
+  font-size: 1rem;
+  color: #cbd5f5;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: #e2e8f0;
+  font-weight: 500;
+}
+
+.form input {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  border-radius: 0.75rem;
+  padding: 0.85rem 1rem;
+  color: #f8fafc;
+  font-size: 1rem;
+}
+
+.form input:focus {
+  outline: 2px solid rgba(99, 102, 241, 0.7);
+  outline-offset: 2px;
+}
+
+.form button {
+  align-self: flex-start;
+  padding: 0.85rem 1.5rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, #4f46e5, #7c3aed);
+  color: #f8fafc;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.4);
+}
+
+.map-wrapper {
+  height: 400px;
+  width: 100%;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+}
+
+.map {
+  height: 100%;
+  width: 100%;
+}
+
+@media (max-width: 720px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .content {
+    padding: 2rem 1rem;
+  }
+
+  .page {
+    padding: 2rem 1.25rem;
+  }
+}

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,0 +1,8 @@
+export default function DashboardPage() {
+  return (
+    <section className="page">
+      <h1>Dashboard</h1>
+      <p>Track your registrations, team updates, and event announcements.</p>
+    </section>
+  )
+}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+  }
+
+  return (
+    <section className="page">
+      <h1>Sign in</h1>
+      <form className="form" onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} required />
+        </label>
+        <label>
+          Password
+          <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} required />
+        </label>
+        <button type="submit">Continue</button>
+      </form>
+    </section>
+  )
+}

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -1,0 +1,31 @@
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
+import 'leaflet/dist/leaflet.css'
+import L from 'leaflet'
+
+const markerIcon = new L.Icon({
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+  shadowSize: [41, 41],
+})
+
+export default function MapPage() {
+  return (
+    <section className="page">
+      <h1>Event map</h1>
+      <div className="map-wrapper">
+        <MapContainer center={[52.2297, 21.0122]} zoom={13} scrollWheelZoom className="map">
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <Marker position={[52.2297, 21.0122]} icon={markerIcon}>
+            <Popup>Hackathon venue</Popup>
+          </Marker>
+        </MapContainer>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/OrganizerPanelPage.jsx
+++ b/frontend/src/pages/OrganizerPanelPage.jsx
@@ -1,0 +1,8 @@
+export default function OrganizerPanelPage() {
+  return (
+    <section className="page">
+      <h1>Organizer panel</h1>
+      <p>Manage schedules, approve participants, and coordinate resources.</p>
+    </section>
+  )
+}

--- a/frontend/src/pages/PublicInfoPage.jsx
+++ b/frontend/src/pages/PublicInfoPage.jsx
@@ -1,0 +1,8 @@
+export default function PublicInfoPage() {
+  return (
+    <section className="page">
+      <h1>Hackathon Overview</h1>
+      <p>Discover the event mission, schedule highlights, and how to get involved.</p>
+    </section>
+  )
+}

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+
+export default function RegisterPage() {
+  const [form, setForm] = useState({ email: '', password: '', confirmPassword: '' })
+
+  const handleChange = (event) => {
+    const { name, value } = event.target
+    setForm((current) => ({ ...current, [name]: value }))
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+  }
+
+  return (
+    <section className="page">
+      <h1>Create account</h1>
+      <form className="form" onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input name="email" type="email" value={form.email} onChange={handleChange} required />
+        </label>
+        <label>
+          Password
+          <input name="password" type="password" value={form.password} onChange={handleChange} required />
+        </label>
+        <label>
+          Confirm password
+          <input name="confirmPassword" type="password" value={form.confirmPassword} onChange={handleChange} required />
+        </label>
+        <button type="submit">Register</button>
+      </form>
+    </section>
+  )
+}

--- a/frontend/src/pages/VolunteerPanelPage.jsx
+++ b/frontend/src/pages/VolunteerPanelPage.jsx
@@ -1,0 +1,8 @@
+export default function VolunteerPanelPage() {
+  return (
+    <section className="page">
+      <h1>Volunteer panel</h1>
+      <p>Review assigned shifts, tasks, and communication updates.</p>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add react-router navigation with dedicated routes for public info, auth, dashboard, and role-specific panels
- create individual page components with shared layout and refreshed styling
- integrate a Leaflet-powered map view placeholder for the event venue

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e11086892883208e29cae9993f8bba