### PR TITLE
Apply brand color palette across frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,36 @@
 - https://mlodzidzialja.pl
 
 ## Opis aplikacji
-Miejsce na szczegółowy opis aplikacji.
+Platforma łącząca młodych mieszkańców z inicjatywami społecznymi w Krakowie. Projekt skupia się na szybkim wyszukiwaniu wydarzeń, rejestracji uczestników oraz wsparciu organizatorów i wolontariuszy w bieżącej komunikacji.
+
+## Paleta kolorów aplikacji „Młodzi Działają”
+Paleta została zbudowana w oparciu o logotyp „Młody Kraków” i obowiązuje we wszystkich elementach interfejsu.
+
+### Kolory bazowe
+- **Primary – Niebieski:** `#0071BC`
+- **Secondary – Różowy/Czerwony:** `#E03C67`
+- **Accent – Zielony:** `#4CAF50`
+
+### Kolory wspierające
+- **Orange/Yellow highlight:** `#F4B400`
+- **Light Blue Gradient:** `#29ABE2`
+
+### Skala neutralna i typografia
+- **Dark Gray (nagłówki):** `#333333`
+- **Medium Gray (teksty pomocnicze):** `#666666`
+- **Light Gray (tła, obramowania):** `#F5F5F5`
+- **White:** `#FFFFFF`
+
+### Gradienty inspirowane logo
+- **Hero Gradient (tła główne, CTA):** `linear-gradient(90deg, #0071BC 0%, #E03C67 100%)`
+- **Highlight Gradient (banery, karty):** `linear-gradient(45deg, #29ABE2 0%, #4CAF50 100%)`
+
+### Zasady stosowania w interfejsie
+- Primary: nagłówki, główne przyciski i aktywne elementy nawigacji.
+- Secondary: kluczowe akcje (CTA), wyróżnienia ikon i stany podkreślające zaangażowanie.
+- Accent: statusy sukcesu, znaczniki kategorii „eko/społeczne”, obramowania map i kart.
+- Orange/Yellow highlight: odznaki, nowości i wyróżnienia ważnych wydarzeń.
+- Skala szarości: powierzchnie tła, karty, formularze oraz teksty pomocnicze.
 
 ## Drużyna: Gorące bobry w Twojej okolicy
 - Mariusz
@@ -14,4 +43,4 @@ Miejsce na szczegółowy opis aplikacji.
 - Grzesiek (Grzechu)
 
 ## Powitanie
-Witamy na HackYeah 2025! Cieszymy się, że możemy być częścią tej energetycznej społeczności twórców i wspólnie podejmować wyzwania. Z radością rozwijamy tu pomysły, dzielimy się doświadczeniem oraz uczymy od siebie nawzajem, bo to miejsce inspiruje i napędza do działania, a każdy krok zbliża nas do realizacji ambitnych zadań, które stawiamy sobie na tej edycji. Razem odkrywamy nowe technologie, iterujemy zwinne rozwiązania i celebrujemy każdą udaną iterację sprintu. Dzięki temu rośniemy co dnia.
+Witamy na HackYeah 2025! Cieszymy się, że możemy być częścią tej energetycznej społeczności twórców i wspólnie podejmować wyzwania. Z radością rozwijamy tu pomysły, dzielimy się doświadczeniem oraz uczymy od siebie nawzajem, bo to miejsce inspiruje i napędza do działania. Każda iteracja sprintu przybliża nas do realizacji ambitnych celów, a zwinne podejście pozwala szybko reagować na potrzeby społeczności.

--- a/frontend/src/main.scss
+++ b/frontend/src/main.scss
@@ -3,7 +3,18 @@
   font-family: 'Inter', system-ui, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  background-color: #0f172a;
+  background-color: #f5f5f5;
+  --color-primary: #0071bc;
+  --color-secondary: #e03c67;
+  --color-accent: #4caf50;
+  --color-highlight: #f4b400;
+  --color-light-blue: #29abe2;
+  --color-dark-gray: #333333;
+  --color-medium-gray: #666666;
+  --color-light-gray: #f5f5f5;
+  --color-white: #ffffff;
+  --gradient-hero: linear-gradient(90deg, #0071bc 0%, #e03c67 100%);
+  --gradient-highlight: linear-gradient(45deg, #29abe2 0%, #4caf50 100%);
 }
 
 * {
@@ -13,8 +24,8 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top left, #1e293b, #0f172a 50%, #020617 100%);
-  color: #e2e8f0;
+  background: linear-gradient(180deg, rgba(244, 244, 244, 0.75), var(--color-light-gray));
+  color: var(--color-dark-gray);
 }
 
 .app {
@@ -30,9 +41,9 @@ body {
   justify-content: space-between;
   gap: 1rem;
   padding: 1.5rem 2rem;
-  background-color: rgba(15, 23, 42, 0.8);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  background: var(--gradient-hero);
+  color: var(--color-white);
+  box-shadow: 0 12px 30px rgba(0, 113, 188, 0.2);
 }
 
 .brand {
@@ -40,6 +51,7 @@ body {
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--color-white);
 }
 
 .nav {
@@ -49,20 +61,22 @@ body {
 }
 
 .nav-link {
-  color: #cbd5f5;
+  color: rgba(255, 255, 255, 0.9);
   text-decoration: none;
   padding: 0.5rem 1rem;
   border-radius: 999px;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .nav-link:hover {
-  background-color: rgba(99, 102, 241, 0.12);
+  background-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 6px 16px rgba(0, 113, 188, 0.25);
 }
 
 .nav-link.active {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
-  color: #f8fafc;
+  background: var(--gradient-highlight);
+  color: var(--color-white);
+  box-shadow: 0 8px 20px rgba(76, 175, 80, 0.25);
 }
 
 .content {
@@ -74,26 +88,26 @@ body {
 
 .page {
   width: min(960px, 100%);
-  background: rgba(15, 23, 42, 0.8);
-  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: var(--color-white);
+  border: 1px solid rgba(0, 113, 188, 0.15);
   border-radius: 1.5rem;
   padding: 2.5rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
 }
 
 h1 {
   margin: 0;
   font-size: clamp(2rem, 4vw, 2.75rem);
-  color: #f8fafc;
+  color: var(--color-primary);
 }
 
 p {
   margin: 0;
   font-size: 1rem;
-  color: #cbd5f5;
+  color: var(--color-medium-gray);
 }
 
 .form {
@@ -106,31 +120,34 @@ p {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  color: #e2e8f0;
+  color: var(--color-dark-gray);
   font-weight: 500;
 }
 
 .form input {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(99, 102, 241, 0.35);
+  background: var(--color-white);
+  border: 1px solid rgba(0, 113, 188, 0.25);
   border-radius: 0.75rem;
   padding: 0.85rem 1rem;
-  color: #f8fafc;
+  color: var(--color-dark-gray);
   font-size: 1rem;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .form input:focus {
-  outline: 2px solid rgba(99, 102, 241, 0.7);
-  outline-offset: 2px;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(0, 113, 188, 0.2);
+  outline: none;
 }
 
 .form button {
   align-self: flex-start;
-  padding: 0.85rem 1.5rem;
+  padding: 0.85rem 1.75rem;
   border-radius: 0.75rem;
   border: none;
-  background: linear-gradient(135deg, #4f46e5, #7c3aed);
-  color: #f8fafc;
+  background: var(--gradient-hero);
+  color: var(--color-white);
   font-weight: 600;
   font-size: 1rem;
   cursor: pointer;
@@ -139,7 +156,7 @@ p {
 
 .form button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.4);
+  box-shadow: 0 12px 24px rgba(224, 60, 103, 0.3);
 }
 
 .map-wrapper {
@@ -147,7 +164,8 @@ p {
   width: 100%;
   border-radius: 1.25rem;
   overflow: hidden;
-  border: 1px solid rgba(99, 102, 241, 0.35);
+  border: 2px solid rgba(76, 175, 80, 0.35);
+  box-shadow: 0 10px 24px rgba(41, 171, 226, 0.2);
 }
 
 .map {


### PR DESCRIPTION
## Summary
- restyle the global layout to follow the "Młodzi Działają" color palette and gradients
- refresh navigation, page cards, forms, and map accents to use the new brand neutrals and highlights
- extend the README with the palette specification and usage guidance for the interface

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e11276da7883209fcc6197442be373