### PR TITLE
Add form control styling to auth forms

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -14,13 +14,13 @@ export default function LoginPage() {
       <form className="form" onSubmit={handleSubmit}>
         <label>
           Email
-          <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} required />
+          <input className="form-controller" type="email" value={email} onChange={(event) => setEmail(event.target.value)} required />
         </label>
         <label>
           Password
-          <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} required />
+          <input className="form-controller" type="password" value={password} onChange={(event) => setPassword(event.target.value)} required />
         </label>
-        <button type="submit">Continue</button>
+        <button className="btn btn-primary" type="submit">Continue</button>
       </form>
     </section>
   )

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -18,17 +18,17 @@ export default function RegisterPage() {
       <form className="form" onSubmit={handleSubmit}>
         <label>
           Email
-          <input name="email" type="email" value={form.email} onChange={handleChange} required />
+          <input className="form-controller" name="email" type="email" value={form.email} onChange={handleChange} required />
         </label>
         <label>
           Password
-          <input name="password" type="password" value={form.password} onChange={handleChange} required />
+          <input className="form-controller" name="password" type="password" value={form.password} onChange={handleChange} required />
         </label>
         <label>
           Confirm password
-          <input name="confirmPassword" type="password" value={form.confirmPassword} onChange={handleChange} required />
+          <input className="form-controller" name="confirmPassword" type="password" value={form.confirmPassword} onChange={handleChange} required />
         </label>
-        <button type="submit">Register</button>
+        <button className="btn btn-primary" type="submit">Register</button>
       </form>
     </section>
   )


### PR DESCRIPTION
## Summary
- add the `form-controller` class to all login and registration inputs
- mark authentication submit buttons with the shared `btn` and `btn-primary` classes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1149960ac8320a4376045d278ca02