### PR TITLE
Improve mobile navigation and layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
-import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, NavLink, Route, Routes, useLocation } from 'react-router-dom'
+import { useEffect, useState } from 'react'
 import PublicInfoPage from './pages/PublicInfoPage.jsx'
 import LoginPage from './pages/LoginPage.jsx'
 import RegisterPage from './pages/RegisterPage.jsx'
@@ -20,29 +21,53 @@ const navigation = [
 export default function App() {
   return (
     <BrowserRouter>
-      <div className="app">
-        <header className="header">
-          <span className="brand">HackYeah 2025</span>
-          <nav className="nav">
-            {navigation.map((item) => (
-              <NavLink key={item.to} to={item.to} className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}>
-                {item.label}
-              </NavLink>
-            ))}
-          </nav>
-        </header>
-        <main className="content">
-          <Routes>
-            <Route path="/" element={<PublicInfoPage />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/register" element={<RegisterPage />} />
-            <Route path="/dashboard" element={<DashboardPage />} />
-            <Route path="/organizer" element={<OrganizerPanelPage />} />
-            <Route path="/volunteer" element={<VolunteerPanelPage />} />
-            <Route path="/map" element={<MapPage />} />
-          </Routes>
-        </main>
-      </div>
+      <AppLayout />
     </BrowserRouter>
+  )
+}
+
+function AppLayout() {
+  const [isNavOpen, setIsNavOpen] = useState(false)
+  const location = useLocation()
+
+  useEffect(() => {
+    setIsNavOpen(false)
+  }, [location.pathname])
+
+  return (
+    <div className="app">
+      <header className="header">
+        <div className="header-bar">
+          <span className="brand">HackYeah 2025</span>
+          <button
+            type="button"
+            className="nav-toggle"
+            aria-expanded={isNavOpen}
+            aria-controls="primary-navigation"
+            onClick={() => setIsNavOpen((current) => !current)}
+          >
+            Menu
+          </button>
+        </div>
+        <nav id="primary-navigation" className={`nav${isNavOpen ? ' nav-open' : ''}`}>
+          {navigation.map((item) => (
+            <NavLink key={item.to} to={item.to} className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}>
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+      </header>
+      <main className="content">
+        <Routes>
+          <Route path="/" element={<PublicInfoPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/organizer" element={<OrganizerPanelPage />} />
+          <Route path="/volunteer" element={<VolunteerPanelPage />} />
+          <Route path="/map" element={<MapPage />} />
+        </Routes>
+      </main>
+    </div>
   )
 }

--- a/frontend/src/main.scss
+++ b/frontend/src/main.scss
@@ -36,41 +36,77 @@ body {
 
 .header {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
   gap: 1rem;
-  padding: 1.5rem 2rem;
+  padding: 1rem 1.25rem;
   background: var(--gradient-hero);
   color: var(--color-white);
   box-shadow: 0 12px 30px rgba(0, 113, 188, 0.2);
 }
 
+.header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
 .brand {
-  font-size: 1.25rem;
+  font-size: 1.125rem;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-white);
 }
 
+.nav-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--color-white);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.nav-toggle:hover,
+.nav-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.3);
+  border-color: rgba(255, 255, 255, 0.9);
+  outline: none;
+}
+
 .nav {
-  display: flex;
-  flex-wrap: wrap;
+  display: none;
+  flex-direction: column;
   gap: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.nav.nav-open {
+  display: flex;
 }
 
 .nav-link {
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(255, 255, 255, 0.95);
   text-decoration: none;
-  padding: 0.5rem 1rem;
+  padding: 0.55rem 1.1rem;
   border-radius: 999px;
   transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.nav-link:hover {
-  background-color: rgba(255, 255, 255, 0.2);
+.nav-link:hover,
+.nav-link:focus-visible {
+  background-color: rgba(255, 255, 255, 0.25);
+  color: var(--color-white);
   box-shadow: 0 6px 16px rgba(0, 113, 188, 0.25);
+  outline: none;
 }
 
 .nav-link.active {
@@ -83,15 +119,15 @@ body {
   flex: 1;
   display: flex;
   justify-content: center;
-  padding: 3rem 1.5rem;
+  padding: 2rem 1.25rem;
 }
 
 .page {
-  width: min(960px, 100%);
+  width: min(100%, 720px);
   background: var(--color-white);
   border: 1px solid rgba(0, 113, 188, 0.15);
   border-radius: 1.5rem;
-  padding: 2.5rem;
+  padding: 2rem 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -160,7 +196,7 @@ p {
 }
 
 .map-wrapper {
-  height: 400px;
+  height: 280px;
   width: 100%;
   border-radius: 1.25rem;
   overflow: hidden;
@@ -173,17 +209,62 @@ p {
   width: 100%;
 }
 
-@media (max-width: 720px) {
+@media (min-width: 600px) {
+  .page {
+    padding: 2.25rem 2rem;
+  }
+
+  .map-wrapper {
+    height: 360px;
+  }
+}
+
+@media (min-width: 768px) {
   .header {
-    flex-direction: column;
-    align-items: flex-start;
+    padding: 1.5rem 2.5rem;
+  }
+
+  .header-bar {
+    align-items: center;
+  }
+
+  .nav-toggle {
+    display: none;
+  }
+
+  .nav {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding-bottom: 0;
   }
 
   .content {
-    padding: 2rem 1rem;
+    padding: 3rem 2.5rem;
   }
 
   .page {
-    padding: 2rem 1.25rem;
+    width: min(960px, 100%);
+    padding: 2.5rem 3rem;
+  }
+
+  .map-wrapper {
+    height: 420px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .header {
+    padding: 1.75rem 3.5rem;
+  }
+
+  .content {
+    padding: 4rem 3.5rem;
+  }
+
+  .page {
+    gap: 2rem;
   }
 }


### PR DESCRIPTION
## Summary
- add a mobile navigation toggle that collapses links on small screens
- refactor global styles to follow a mobile-first responsive layout with updated spacing and map sizing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e116866b648320a5b900ac7598c127