### PR TITLE
Implement mobile-first header navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom'
 import PublicInfoPage from './pages/PublicInfoPage.jsx'
 import LoginPage from './pages/LoginPage.jsx'
@@ -18,14 +19,39 @@ const navigation = [
 ]
 
 export default function App() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const toggleMenu = () => {
+    setIsMenuOpen((current) => !current)
+  }
+
+  const handleNavigation = () => {
+    setIsMenuOpen(false)
+  }
+
   return (
     <BrowserRouter>
       <div className="app">
         <header className="header">
           <span className="brand">HackYeah 2025</span>
-          <nav className="nav">
+          <button
+            type="button"
+            className="menu-toggle"
+            aria-expanded={isMenuOpen}
+            aria-controls="primary-navigation"
+            onClick={toggleMenu}
+          >
+            Menu
+            <span aria-hidden="true" className="menu-icon">☰</span>
+          </button>
+          <nav id="primary-navigation" className={isMenuOpen ? 'nav is-open' : 'nav'}>
             {navigation.map((item) => (
-              <NavLink key={item.to} to={item.to} className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}>
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+                onClick={handleNavigation}
+              >
                 {item.label}
               </NavLink>
             ))}

--- a/frontend/src/main.scss
+++ b/frontend/src/main.scss
@@ -1,11 +1,9 @@
 $color-primary-start: #2b64a9;
 $color-primary-end: #df486d;
 $color-primary-mid: #3091ce;
-
 $color-secondary: #ae214e;
 $color-accent: #ffbf3d;
 $color-green: #659b2d;
-
 $color-text: #222;
 $color-bg: #fff;
 $color-input-bg: #f5f5f5;
@@ -13,34 +11,184 @@ $color-input-border: #ccc;
 $border-radius: 6px;
 $focus-shadow: 0 0 0 2px rgba(48, 145, 206, 0.4);
 
+@use 'sass:color';
+
+* {
+  box-sizing: border-box;
+}
+
 body {
   background: $color-bg;
   color: $color-text;
   font-family: 'Inter', Arial, sans-serif;
   font-size: 1rem;
   margin: 0;
-  padding: 0;
+  min-height: 100vh;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   color: $color-text;
   font-weight: 700;
   margin: 1.2em 0 0.6em 0;
   line-height: 1.2;
 }
 
-h1 { font-size: 2rem; }
-h2 { font-size: 1.5rem; }
-h3 { font-size: 1.25rem; }
-h4 { font-size: 1.1rem; }
-h5 { font-size: 1rem; }
-h6 { font-size: 0.9rem; }
+h1 {
+  font-size: 1.75rem;
+}
 
-p, span {
+h2 {
+  font-size: 1.4rem;
+}
+
+h3 {
+  font-size: 1.2rem;
+}
+
+h4 {
+  font-size: 1.1rem;
+}
+
+h5 {
+  font-size: 1rem;
+}
+
+h6 {
+  font-size: 0.9rem;
+}
+
+p,
+span {
   color: $color-text;
   font-size: 1rem;
   line-height: 1.6;
   margin: 0 0 1em 0;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, rgba(43, 100, 169, 0.08), rgba(223, 72, 109, 0.08));
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: linear-gradient(135deg, $color-primary-start, $color-primary-end);
+  color: #fff;
+}
+
+.brand {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.menu-toggle {
+  align-self: flex-end;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: $border-radius;
+  background: transparent;
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.menu-toggle:hover,
+.menu-toggle:focus {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+.menu-toggle:focus {
+  outline: none;
+  box-shadow: $focus-shadow;
+}
+
+.menu-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.nav {
+  display: none;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.nav.is-open {
+  display: flex;
+}
+
+.nav-link {
+  display: block;
+  padding: 0.6rem 0.75rem;
+  border-radius: $border-radius;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.nav-link:hover,
+.nav-link:focus {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.nav-link:focus {
+  outline: none;
+  box-shadow: $focus-shadow;
+}
+
+.nav-link.active {
+  background-color: #fff;
+  color: $color-primary-start;
+}
+
+.content {
+  flex: 1;
+  width: 100%;
+  padding: 1.5rem 1rem 2.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.page {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 640px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
 }
 
 .form-controller {
@@ -53,24 +201,26 @@ p, span {
   font-size: 1rem;
   color: $color-text;
   transition: border-color 0.2s, box-shadow 0.2s, background-color 0.2s;
-  margin-bottom: 1em;
-  box-sizing: border-box;
+  margin-bottom: 0;
+}
 
-  &:focus {
-    border-color: $color-primary-mid;
-    outline: none;
-    box-shadow: $focus-shadow;
-    background: $color-bg;
-  }
+.form-controller:focus {
+  border-color: $color-primary-mid;
+  outline: none;
+  box-shadow: $focus-shadow;
+  background: $color-bg;
+}
 
-  &:hover {
-    border-color: $color-primary-mid;
-    background-color: rgba(48, 145, 206, 0.1);
-  }
+.form-controller:hover {
+  border-color: $color-primary-mid;
+  background-color: rgba(48, 145, 206, 0.1);
 }
 
 .btn {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
   padding: 0.6em 1.2em;
   border-radius: $border-radius;
   font-size: 1rem;
@@ -78,32 +228,103 @@ p, span {
   text-align: center;
   cursor: pointer;
   border: none;
-  transition: background-color 0.2s, color 0.2s;
+  transition: background-color 0.2s, color 0.2s, transform 0.2s;
+}
+
+.btn:focus {
+  outline: none;
+  box-shadow: $focus-shadow;
 }
 
 .btn-primary {
   background-color: $color-primary-mid;
   color: #fff;
+}
 
-  &:hover,
-  &:focus {
-    background-color: $color-primary-start;
-  }
+.btn-primary:hover,
+.btn-primary:focus {
+  background-color: $color-primary-start;
 }
 
 .btn-secondary {
   background-color: $color-secondary;
   color: #fff;
-
-  &:hover,
-  &:focus {
-    background-color: #8e1a3f;
 }
 
-@media (max-width: 600px) {
-  h1 { font-size: 1.5rem; }
-  h2 { font-size: 1.2rem; }
-  h3 { font-size: 1.1rem; }
-  p, .form-controller, .btn { font-size: 0.95rem; }
+.btn-secondary:hover,
+.btn-secondary:focus {
+  background-color: #8e1a3f;
 }
+
+.btn-accent {
+  background-color: $color-accent;
+  color: #222;
+}
+
+.btn-accent:hover,
+.btn-accent:focus {
+  background-color: color.adjust($color-accent, $lightness: -8%);
+}
+
+.alert-success {
+  padding: 0.75rem 1rem;
+  border-radius: $border-radius;
+  background: rgba($color-green, 0.1);
+  color: $color-green;
+  font-weight: 600;
+}
+
+@media (min-width: 640px) {
+  h1 {
+    font-size: 2rem;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+  }
+
+  h3 {
+    font-size: 1.25rem;
+  }
+
+  .header {
+    flex-direction: row;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  .menu-toggle {
+    display: none;
+  }
+
+  .nav {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.75rem;
+    width: auto;
+  }
+
+  .nav-link {
+    background-color: transparent;
+  }
+
+  .nav-link.active {
+    background-color: rgba(255, 255, 255, 0.2);
+    color: #fff;
+  }
+
+  .content {
+    padding: 2rem 2rem 3rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .content {
+    padding: 3rem 3rem 4rem;
+  }
+
+  .page {
+    max-width: 720px;
+  }
 }


### PR DESCRIPTION
## Summary
- add a responsive navigation toggle to the header and close the menu after navigation
- expand the shared stylesheet with mobile-first layout, navigation, and button styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1183520cc8320a4d29738ee8b84f1