### PR TITLE
Update public landing copy and header branding

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,7 +33,7 @@ export default function App() {
     <BrowserRouter>
       <div className="app">
         <header className="header">
-          <span className="brand">HackYeah 2025</span>
+          <span className="brand">Młodzi działają</span>
           <button
             type="button"
             className="menu-toggle"

--- a/frontend/src/pages/PublicInfoPage.jsx
+++ b/frontend/src/pages/PublicInfoPage.jsx
@@ -1,8 +1,24 @@
 export default function PublicInfoPage() {
   return (
     <section className="page">
-      <h1>Hackathon Overview</h1>
-      <p>Discover the event mission, schedule highlights, and how to get involved.</p>
+      <h1>Młodzi Działają</h1>
+      <p>
+        Młodzi Działają to cyfrowa platforma, która pomaga młodym wolontariuszom znaleźć inicjatywy w Krakowie,
+        a organizacjom i szkołom sprawnie zarządzać ich zaangażowaniem.
+      </p>
+      <p>
+        Naszym celem jest stworzenie jednego, wiarygodnego miejsca współpracy między młodzieżą, organizacjami i koordynatorami,
+        aby każdy wolontariusz mógł bezpiecznie rozwijać umiejętności i realnie wpływać na lokalną społeczność.
+      </p>
+      <h2>Jakie wyzwania rozwiązujemy?</h2>
+      <ul>
+        <li>Ułatwiamy organizacjom docieranie z ofertami do młodych ludzi w atrakcyjnej i przejrzystej formie.</li>
+        <li>Zapewniamy szkołom narzędzia do formalnego prowadzenia i raportowania wolontariatu uczniów, w tym osób U18.</li>
+        <li>
+          Budujemy przestrzeń, która wspiera bezpieczną komunikację, zarządzanie zgodami oraz dokumentowanie efektów działań.
+        </li>
+        <li>Pomagamy wolontariuszom odkrywać inicjatywy dopasowane do ich zainteresowań i budować portfolio aktywności.</li>
+      </ul>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- replace the header brand label with "Młodzi działają"
- expand the public landing page content with description and problem statements inspired by the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e11aafa6208320a30ace802fd8c086