### PR TITLE
Fix website URL in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,4 +168,4 @@ Paleta została zbudowana w oparciu o logotyp „Młody Kraków” i obowiązuje
 - interweniuje przy nadużyciach (moderacja).
 
 ## Adres strony
-- https://mlodzidzialja.pl
+- https://mlodzidzialaja.pl


### PR DESCRIPTION
## Summary
- update the README to use the correct mlodzidzialaja.pl domain in the site address section

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e11e5f04048320a771f00d576fac8e