### PR TITLE
Integrate React frontend with Ory authentication flows

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,16 +1,52 @@
-# React + Vite
+# Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Interfejs został przygotowany w oparciu o Vite i React. Aplikacja integruje się z platformą [Ory](https://www.ory.sh/) i obsługuje logowanie, rejestrację oraz ochronę tras w oparciu o sesję użytkownika.
 
-Currently, two official plugins are available:
+## Wymagania
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Node.js 18+
+- Skonfigurowany projekt w Ory Network (lub własna instancja Ory Kratos)
+- Działający tunel `ory tunnel` podczas pracy lokalnej
 
-## React Compiler
+## Konfiguracja środowiska
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+1. Zainstaluj zależności:
+   ```bash
+   npm install
+   ```
+2. Ustaw zmienną środowiskową z adresem SDK Ory (domyślnie `http://localhost:4000` – taki adres wystawia tunel Ory):
+   ```bash
+   export VITE_ORY_SDK_URL="http://localhost:4000"
+   ```
+3. Uruchom tunel wskazując adres aplikacji (domyślnie `http://localhost:5173`):
+   ```bash
+   ory tunnel --project <ID_PROJEKTU> http://localhost:5173
+   ```
 
-## Expanding the ESLint configuration
+## Start aplikacji
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```bash
+npm run dev
+```
+
+Aplikacja domyślnie nasłuchuje na porcie `5173`.
+
+## Dostępne funkcje
+
+- Rejestracja i logowanie przy użyciu natywnych flow Ory.
+- Automatyczne odświeżanie sesji oraz przycisk wylogowania.
+- Ochrona tras paneli (dashboard, organizer, volunteer) przed dostępem bez zalogowania.
+- Wyświetlanie podstawowych danych profilu użytkownika po zalogowaniu.
+
+## Struktura kodu
+
+- `src/providers/AuthProvider.jsx` – konfiguracja Ory SDK i kontekst sesji.
+- `src/components/OryFlowForm.jsx` – uniwersalny renderer formularzy Ory (logowanie/rejestracja).
+- `src/routes/ProtectedRoute.jsx` – ochrona tras z wykorzystaniem sesji.
+- `src/pages` – widoki stron, m.in. integracja flow logowania i rejestracji.
+
+## Przydatne komendy
+
+- `npm run lint` – uruchamia ESLint.
+- `npm run build` – buduje wersję produkcyjną.
+- `npm run preview` – uruchamia podgląd zbudowanej aplikacji.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@ory/client-fetch": "^1.22.3",
+        "@tanstack/react-query": "^5.90.2",
         "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1010,6 +1012,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@ory/client-fetch": {
+      "version": "1.22.3",
+      "resolved": "https://registry.npmjs.org/@ory/client-fetch/-/client-fetch-1.22.3.tgz",
+      "integrity": "sha512-yDLKvJCkxtriSTiWpOsWnagCkD0L1QFrJwhBfP9l+cfMKmGKF9wWu4gRfi7PRdxo4NFRdulW0IGZZf8t2ayZAw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
@@ -1631,6 +1639,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ory/client-fetch": "^1.22.3",
+    "@tanstack/react-query": "^5.90.2",
     "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom'
 import PublicInfoPage from './pages/PublicInfoPage.jsx'
 import LoginPage from './pages/LoginPage.jsx'
@@ -7,11 +7,18 @@ import DashboardPage from './pages/DashboardPage.jsx'
 import OrganizerPanelPage from './pages/OrganizerPanelPage.jsx'
 import VolunteerPanelPage from './pages/VolunteerPanelPage.jsx'
 import MapPage from './pages/MapPage.jsx'
+import { useAuth } from './providers/useAuth.js'
+import ProtectedRoute from './routes/ProtectedRoute.jsx'
 
-const navigation = [
+const publicNavigation = [
   { to: '/', label: 'Start' },
   { to: '/login', label: 'Log in' },
   { to: '/register', label: 'Register' },
+  { to: '/map', label: 'Map' },
+]
+
+const privateNavigation = [
+  { to: '/', label: 'Start' },
   { to: '/dashboard', label: 'Dashboard' },
   { to: '/organizer', label: 'Organizer' },
   { to: '/volunteer', label: 'Volunteer' },
@@ -19,7 +26,10 @@ const navigation = [
 ]
 
 export default function App() {
+  const { session, logout } = useAuth()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const navigation = useMemo(() => (session ? privateNavigation : publicNavigation), [session])
 
   const toggleMenu = () => {
     setIsMenuOpen((current) => !current)
@@ -29,11 +39,31 @@ export default function App() {
     setIsMenuOpen(false)
   }
 
+  const handleLogout = async () => {
+    setIsMenuOpen(false)
+    await logout()
+  }
+
+  const accountLabel = useMemo(() => {
+    const traits = session?.identity?.traits
+    if (!traits) {
+      return null
+    }
+    if (typeof traits.email === 'string' && traits.email.length > 0) {
+      return traits.email
+    }
+    if (typeof traits.username === 'string' && traits.username.length > 0) {
+      return traits.username
+    }
+    return session?.identity?.id ?? null
+  }, [session])
+
   return (
     <BrowserRouter>
       <div className="app">
         <header className="header">
           <span className="brand">HackYeah 2025</span>
+          {accountLabel ? <span className="account-chip">{accountLabel}</span> : null}
           <button
             type="button"
             className="menu-toggle"
@@ -55,6 +85,11 @@ export default function App() {
                 {item.label}
               </NavLink>
             ))}
+            {session ? (
+              <button type="button" className="nav-link nav-link--button" onClick={handleLogout}>
+                Log out
+              </button>
+            ) : null}
           </nav>
         </header>
         <main className="content">
@@ -62,9 +97,30 @@ export default function App() {
             <Route path="/" element={<PublicInfoPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
-            <Route path="/dashboard" element={<DashboardPage />} />
-            <Route path="/organizer" element={<OrganizerPanelPage />} />
-            <Route path="/volunteer" element={<VolunteerPanelPage />} />
+            <Route
+              path="/dashboard"
+              element={(
+                <ProtectedRoute>
+                  <DashboardPage />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/organizer"
+              element={(
+                <ProtectedRoute>
+                  <OrganizerPanelPage />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/volunteer"
+              element={(
+                <ProtectedRoute>
+                  <VolunteerPanelPage />
+                </ProtectedRoute>
+              )}
+            />
             <Route path="/map" element={<MapPage />} />
           </Routes>
         </main>

--- a/frontend/src/components/OryFlowForm.jsx
+++ b/frontend/src/components/OryFlowForm.jsx
@@ -1,0 +1,158 @@
+const messageTypeClass = {
+  error: 'flow-message flow-message--error',
+  success: 'flow-message flow-message--success',
+  info: 'flow-message flow-message--info',
+}
+
+const defaultMessageClass = 'flow-message'
+
+function NodeMessages({ messages }) {
+  if (!messages || messages.length === 0) {
+    return null
+  }
+
+  return (
+    <ul className="flow-messages" role="alert">
+      {messages.map((message) => (
+        <li key={message.id} className={messageTypeClass[message.type] || defaultMessageClass}>
+          {message.text}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function FieldMessages({ messages }) {
+  if (!messages || messages.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flow-field-messages" role="alert">
+      {messages.map((message) => (
+        <p key={message.id} className={messageTypeClass[message.type] || defaultMessageClass}>
+          {message.text}
+        </p>
+      ))}
+    </div>
+  )
+}
+
+function FlowNode({ node, isSubmitting }) {
+  const { attributes, meta, messages, type } = node
+
+  if (attributes.node_type === 'input') {
+    if (attributes.type === 'hidden') {
+      return <input type="hidden" name={attributes.name} value={attributes.value ?? ''} />
+    }
+
+    if (attributes.type === 'submit') {
+      return (
+        <div className="flow-actions">
+          <button
+            className="btn btn-primary"
+            type="submit"
+            name={attributes.name}
+            value={attributes.value ?? ''}
+            disabled={attributes.disabled || isSubmitting}
+          >
+            {attributes.label?.text || meta.label?.text || attributes.value || 'Continue'}
+          </button>
+        </div>
+      )
+    }
+
+    if (attributes.type === 'button') {
+      return (
+        <div className="flow-actions">
+          <button
+            className="btn"
+            type="button"
+            name={attributes.name}
+            value={attributes.value ?? ''}
+            disabled={attributes.disabled || isSubmitting}
+          >
+            {attributes.label?.text || meta.label?.text || attributes.value || 'Continue'}
+          </button>
+        </div>
+      )
+    }
+
+    if (attributes.type === 'checkbox') {
+      return (
+        <label className="flow-field flow-field--checkbox">
+          <input
+            type="checkbox"
+            name={attributes.name}
+            defaultChecked={Boolean(attributes.value)}
+            value={attributes.value ?? 'true'}
+            disabled={attributes.disabled || isSubmitting}
+          />
+          <span>{attributes.label?.text || meta.label?.text || attributes.name}</span>
+          <FieldMessages messages={messages} />
+        </label>
+      )
+    }
+
+    const fieldId = attributes.name || `${attributes.node_type}-${attributes.type}`
+
+    return (
+      <div className="flow-field">
+        <label htmlFor={fieldId}>
+          <span className="flow-label">{attributes.label?.text || meta.label?.text || attributes.name}</span>
+          <input
+            id={fieldId}
+            className="form-controller"
+            name={attributes.name}
+            type={attributes.type}
+            defaultValue={attributes.value ?? ''}
+            autoComplete={attributes.autocomplete}
+            pattern={attributes.pattern}
+            required={attributes.required}
+            maxLength={attributes.maxlength}
+            minLength={attributes.minlength}
+            disabled={attributes.disabled || isSubmitting}
+          />
+        </label>
+        <FieldMessages messages={messages} />
+      </div>
+    )
+  }
+
+  if (attributes.node_type === 'text') {
+    return <p className="flow-text">{attributes.text.text}</p>
+  }
+
+  if (attributes.node_type === 'a') {
+    return (
+      <a className="flow-link" href={attributes.href}>
+        {attributes.title?.text || attributes.href}
+      </a>
+    )
+  }
+
+  if (type === 'img' && attributes.node_type === 'img') {
+    return <img className="flow-image" src={attributes.src} alt={attributes.alt ?? ''} />
+  }
+
+  return null
+}
+
+export default function OryFlowForm({ flow, onSubmit, isSubmitting }) {
+  if (!flow) {
+    return null
+  }
+
+  return (
+    <form className="form flow-form" action={flow.ui.action} method={flow.ui.method} onSubmit={onSubmit} noValidate>
+      <NodeMessages messages={flow.ui.messages} />
+      {flow.ui.nodes.map((node, index) => (
+        <FlowNode
+          key={`${node.group}-${node.attributes?.name || node.attributes?.id || index}`}
+          node={node}
+          isSubmitting={isSubmitting}
+        />
+      ))}
+    </form>
+  )
+}

--- a/frontend/src/hooks/useOryFlowNavigation.js
+++ b/frontend/src/hooks/useOryFlowNavigation.js
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+function sanitizeReturnTo(returnToParam) {
+  if (!returnToParam) {
+    return null
+  }
+  try {
+    const target = new URL(returnToParam, window.location.origin)
+    if (target.origin !== window.location.origin) {
+      return null
+    }
+    return `${target.pathname}${target.search}${target.hash}`
+  } catch (error) {
+    console.error('Invalid return_to parameter ignored', error)
+    return null
+  }
+}
+
+export function useOryFlowNavigation() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const flowId = searchParams.get('flow')
+  const returnToParam = searchParams.get('return_to')
+
+  const sanitizedReturnTo = useMemo(() => sanitizeReturnTo(returnToParam), [returnToParam])
+
+  const absoluteReturnTo = useMemo(() => {
+    if (!sanitizedReturnTo) {
+      return undefined
+    }
+    return new URL(sanitizedReturnTo, window.location.origin).toString()
+  }, [sanitizedReturnTo])
+
+  const syncSearchParams = useCallback(
+    (nextFlow) => {
+      const params = new URLSearchParams()
+      if (sanitizedReturnTo) {
+        params.set('return_to', sanitizedReturnTo)
+      }
+      if (nextFlow?.id) {
+        params.set('flow', nextFlow.id)
+      }
+      setSearchParams(params, { replace: true })
+    },
+    [sanitizedReturnTo, setSearchParams],
+  )
+
+  return { flowId, sanitizedReturnTo, absoluteReturnTo, syncSearchParams }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './main.scss';
+import './main.scss'
 import App from './App.jsx'
+import { AuthProvider } from './providers/AuthProvider.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )

--- a/frontend/src/main.scss
+++ b/frontend/src/main.scss
@@ -92,6 +92,18 @@ span {
   color: #fff;
 }
 
+.account-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
 .menu-toggle {
   align-self: flex-end;
   display: inline-flex;
@@ -143,6 +155,9 @@ span {
   color: #fff;
   font-weight: 600;
   text-decoration: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
   transition: background-color 0.2s, color 0.2s;
 }
 
@@ -160,6 +175,10 @@ span {
 .nav-link.active {
   background-color: #fff;
   color: $color-primary-start;
+}
+
+.nav-link--button {
+  font: inherit;
 }
 
 .content {
@@ -181,6 +200,104 @@ span {
 .form {
   display: flex;
   flex-direction: column;
+}
+
+.flow-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.flow-messages {
+  list-style: none;
+  margin: 0 0 1rem 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.flow-message {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.flow-message--error {
+  color: #8e1a3f;
+}
+
+.flow-message--success {
+  color: $color-green;
+}
+
+.flow-message--info {
+  color: $color-primary-mid;
+}
+
+.flow-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.flow-field--checkbox {
+  flex-direction: row;
+  align-items: center;
+}
+
+.flow-label {
+  font-weight: 600;
+}
+
+.flow-field-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.flow-text {
+  margin: 0 0 1rem 0;
+  color: $color-text;
+}
+
+.flow-link {
+  color: $color-primary-mid;
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.flow-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.flow-retry {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: $border-radius;
+  padding: 1rem;
+  box-shadow: 0 10px 30px rgba(17, 34, 68, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card-pre {
+  margin: 0;
+  background: $color-input-bg;
+  padding: 0.75rem;
+  border-radius: $border-radius;
+  overflow-x: auto;
+  font-size: 0.9rem;
+  line-height: 1.4;
 }
 
 label {

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,8 +1,19 @@
+import { useAuth } from '../providers/useAuth.js'
+
 export default function DashboardPage() {
+  const { session } = useAuth()
+  const traits = session?.identity?.traits ?? null
+
   return (
     <section className="page">
       <h1>Dashboard</h1>
       <p>Track your registrations, team updates, and event announcements.</p>
+      {traits ? (
+        <div className="card">
+          <h2>Your profile</h2>
+          <pre className="card-pre">{JSON.stringify(traits, null, 2)}</pre>
+        </div>
+      ) : null}
     </section>
   )
 }

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,27 +1,129 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ResponseError } from '@ory/client-fetch'
+import OryFlowForm from '../components/OryFlowForm.jsx'
+import { ory } from '../services/ory.js'
+import { useAuth } from '../providers/useAuth.js'
+import { useOryFlowNavigation } from '../hooks/useOryFlowNavigation.js'
+
+const FLOW_RESET_STATUSES = new Set([403, 404, 410])
 
 export default function LoginPage() {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
+  const { flowId, sanitizedReturnTo, absoluteReturnTo, syncSearchParams } = useOryFlowNavigation()
+  const [flow, setFlow] = useState(null)
+  const [isInitializing, setIsInitializing] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [formError, setFormError] = useState('')
+  const navigate = useNavigate()
+  const { refresh } = useAuth()
 
-  const handleSubmit = (event) => {
+  const restartFlow = useCallback(() => {
+    setFlow(null)
+    syncSearchParams(null)
+  }, [syncSearchParams])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadFlow() {
+      setIsInitializing(true)
+      try {
+        if (flowId) {
+          const existingFlow = await ory.getLoginFlow({ id: flowId })
+          if (cancelled) {
+            return
+          }
+          setFlow(existingFlow)
+          setFormError('')
+          return
+        }
+
+        const newFlow = await ory.createBrowserLoginFlow({ returnTo: absoluteReturnTo })
+        if (cancelled) {
+          return
+        }
+        setFlow(newFlow)
+        syncSearchParams(newFlow)
+        setFormError('')
+      } catch (error) {
+        if (cancelled) {
+          return
+        }
+        if (error instanceof ResponseError && error.response && FLOW_RESET_STATUSES.has(error.response.status)) {
+          restartFlow()
+          return
+        }
+        console.error('Unable to initialize login flow', error)
+        setFormError('We could not reach the authentication service. Please try again.')
+      } finally {
+        if (!cancelled) {
+          setIsInitializing(false)
+        }
+      }
+    }
+
+    loadFlow()
+
+    return () => {
+      cancelled = true
+    }
+  }, [flowId, absoluteReturnTo, syncSearchParams, restartFlow])
+
+  const handleSubmit = async (event) => {
     event.preventDefault()
+    if (!flow) {
+      restartFlow()
+      return
+    }
+
+    setIsSubmitting(true)
+    setFormError('')
+
+    const formData = new FormData(event.currentTarget)
+    const payload = Object.fromEntries(formData.entries())
+
+    try {
+      await ory.updateLoginFlow({
+        flow: flow.id,
+        updateLoginFlowBody: payload,
+      })
+      await refresh()
+      navigate(sanitizedReturnTo || '/dashboard', { replace: true })
+    } catch (error) {
+      if (error instanceof ResponseError && error.response) {
+        if (error.response.status === 400) {
+          const data = await error.response.json()
+          setFlow(data)
+          return
+        }
+        if (FLOW_RESET_STATUSES.has(error.response.status)) {
+          restartFlow()
+          return
+        }
+      }
+      console.error('Login failed', error)
+      setFormError('Login failed. Please review the form and try again.')
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   return (
     <section className="page">
       <h1>Sign in</h1>
-      <form className="form" onSubmit={handleSubmit}>
-        <label>
-          Email
-          <input className="form-controller" type="email" value={email} onChange={(event) => setEmail(event.target.value)} required />
-        </label>
-        <label>
-          Password
-          <input className="form-controller" type="password" value={password} onChange={(event) => setPassword(event.target.value)} required />
-        </label>
-        <button className="btn btn-primary" type="submit">Continue</button>
-      </form>
+      {formError ? <p className="flow-message flow-message--error">{formError}</p> : null}
+      {isInitializing ? (
+        <p>Loading login form...</p>
+      ) : flow ? (
+        <OryFlowForm flow={flow} onSubmit={handleSubmit} isSubmitting={isSubmitting} />
+      ) : (
+        <div className="flow-retry">
+          <p>We could not load the login form.</p>
+          <button type="button" className="btn btn-primary" onClick={restartFlow}>
+            Try again
+          </button>
+        </div>
+      )}
     </section>
   )
 }

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,35 +1,150 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ResponseError } from '@ory/client-fetch'
+import OryFlowForm from '../components/OryFlowForm.jsx'
+import { ory } from '../services/ory.js'
+import { useAuth } from '../providers/useAuth.js'
+import { useOryFlowNavigation } from '../hooks/useOryFlowNavigation.js'
+
+const FLOW_RESET_STATUSES = new Set([403, 404, 410])
 
 export default function RegisterPage() {
-  const [form, setForm] = useState({ email: '', password: '', confirmPassword: '' })
+  const { flowId, sanitizedReturnTo, absoluteReturnTo, syncSearchParams } = useOryFlowNavigation()
+  const [flow, setFlow] = useState(null)
+  const [isInitializing, setIsInitializing] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [formError, setFormError] = useState('')
+  const [successMessage, setSuccessMessage] = useState('')
+  const navigate = useNavigate()
+  const { refresh } = useAuth()
 
-  const handleChange = (event) => {
-    const { name, value } = event.target
-    setForm((current) => ({ ...current, [name]: value }))
-  }
+  const restartFlow = useCallback(() => {
+    setFlow(null)
+    syncSearchParams(null)
+  }, [syncSearchParams])
 
-  const handleSubmit = (event) => {
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadFlow() {
+      setIsInitializing(true)
+      try {
+        if (flowId) {
+          const existingFlow = await ory.getRegistrationFlow({ id: flowId })
+          if (cancelled) {
+            return
+          }
+          setFlow(existingFlow)
+          setFormError('')
+          return
+        }
+
+        const newFlow = await ory.createBrowserRegistrationFlow({ returnTo: absoluteReturnTo })
+        if (cancelled) {
+          return
+        }
+        setFlow(newFlow)
+        syncSearchParams(newFlow)
+        setFormError('')
+      } catch (error) {
+        if (cancelled) {
+          return
+        }
+        if (error instanceof ResponseError && error.response && FLOW_RESET_STATUSES.has(error.response.status)) {
+          restartFlow()
+          return
+        }
+        console.error('Unable to initialize registration flow', error)
+        setFormError('We could not reach the authentication service. Please try again.')
+      } finally {
+        if (!cancelled) {
+          setIsInitializing(false)
+        }
+      }
+    }
+
+    loadFlow()
+
+    return () => {
+      cancelled = true
+    }
+  }, [flowId, absoluteReturnTo, syncSearchParams, restartFlow])
+
+  const handleSubmit = async (event) => {
     event.preventDefault()
+    if (!flow) {
+      restartFlow()
+      return
+    }
+
+    setIsSubmitting(true)
+    setFormError('')
+    setSuccessMessage('')
+
+    const formData = new FormData(event.currentTarget)
+    const payload = Object.fromEntries(formData.entries())
+
+    try {
+      const result = await ory.updateRegistrationFlow({
+        flow: flow.id,
+        updateRegistrationFlowBody: payload,
+      })
+
+      if (result.session) {
+        await refresh()
+        navigate(sanitizedReturnTo || '/dashboard', { replace: true })
+        return
+      }
+
+      const redirectInstruction = result.continue_with?.find((item) => item.action === 'redirect_browser_to')
+      if (redirectInstruction?.redirect_browser_to) {
+        window.location.href = redirectInstruction.redirect_browser_to
+        return
+      }
+
+      const requiresVerification = result.continue_with?.some((item) => item.action === 'show_verification_ui')
+      if (requiresVerification) {
+        setSuccessMessage('Registration completed. Please verify your email address before signing in.')
+      } else {
+        setSuccessMessage('Registration completed. You can now sign in.')
+      }
+      restartFlow()
+    } catch (error) {
+      if (error instanceof ResponseError && error.response) {
+        if (error.response.status === 400) {
+          const data = await error.response.json()
+          setFlow(data)
+          return
+        }
+        if (FLOW_RESET_STATUSES.has(error.response.status)) {
+          restartFlow()
+          return
+        }
+      }
+      console.error('Registration failed', error)
+      setFormError('Registration failed. Please review the form and try again.')
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   return (
     <section className="page">
       <h1>Create account</h1>
-      <form className="form" onSubmit={handleSubmit}>
-        <label>
-          Email
-          <input className="form-controller" name="email" type="email" value={form.email} onChange={handleChange} required />
-        </label>
-        <label>
-          Password
-          <input className="form-controller" name="password" type="password" value={form.password} onChange={handleChange} required />
-        </label>
-        <label>
-          Confirm password
-          <input className="form-controller" name="confirmPassword" type="password" value={form.confirmPassword} onChange={handleChange} required />
-        </label>
-        <button className="btn btn-primary" type="submit">Register</button>
-      </form>
+      {successMessage ? <p className="flow-message flow-message--success">{successMessage}</p> : null}
+      {formError ? <p className="flow-message flow-message--error">{formError}</p> : null}
+      {isInitializing ? (
+        <p>Loading registration form...</p>
+      ) : flow ? (
+        <OryFlowForm flow={flow} onSubmit={handleSubmit} isSubmitting={isSubmitting} />
+      ) : (
+        <div className="flow-retry">
+          <p>We could not load the registration form.</p>
+          <button type="button" className="btn btn-primary" onClick={restartFlow}>
+            Try again
+          </button>
+        </div>
+      )}
     </section>
   )
 }

--- a/frontend/src/providers/AuthContext.js
+++ b/frontend/src/providers/AuthContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react'
+
+export const AuthContext = createContext(null)

--- a/frontend/src/providers/AuthProvider.jsx
+++ b/frontend/src/providers/AuthProvider.jsx
@@ -1,0 +1,79 @@
+import { useCallback, useMemo } from 'react'
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
+import { ResponseError } from '@ory/client-fetch'
+import { AuthContext } from './AuthContext.js'
+import { ory } from '../services/ory.js'
+
+function AuthContextProvider({ children }) {
+  const {
+    data: session,
+    isPending,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['session'],
+    queryFn: async () => {
+      try {
+        return await ory.toSession()
+      } catch (requestError) {
+        if (requestError instanceof ResponseError) {
+          if (requestError.response.status === 401) {
+            return null
+          }
+          throw requestError
+        }
+        console.warn('Unable to reach the authentication service', requestError)
+        return null
+      }
+    },
+    retry: false,
+    staleTime: 30000,
+  })
+
+  const logout = useCallback(async () => {
+    try {
+      const flow = await ory.createBrowserLogoutFlow()
+      if (flow.logout_url) {
+        window.location.href = flow.logout_url
+        return
+      }
+    } catch (requestError) {
+      if (!(requestError instanceof ResponseError && requestError.response.status === 401)) {
+        console.error('Unable to start logout flow', requestError)
+      }
+    }
+    await refetch()
+  }, [refetch])
+
+  const value = useMemo(
+    () => ({
+      session: session ?? null,
+      isLoading: isPending,
+      isError,
+      error: error ?? null,
+      refresh: refetch,
+      logout,
+    }),
+    [session, isPending, isError, error, refetch, logout],
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+})
+
+export function AuthProvider({ children }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthContextProvider>{children}</AuthContextProvider>
+    </QueryClientProvider>
+  )
+}

--- a/frontend/src/providers/useAuth.js
+++ b/frontend/src/providers/useAuth.js
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { AuthContext } from './AuthContext.js'
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider')
+  }
+  return context
+}

--- a/frontend/src/routes/ProtectedRoute.jsx
+++ b/frontend/src/routes/ProtectedRoute.jsx
@@ -1,0 +1,26 @@
+import { Navigate, useLocation } from 'react-router-dom'
+import { useAuth } from '../providers/useAuth.js'
+
+export default function ProtectedRoute({ children }) {
+  const { session, isLoading } = useAuth()
+  const location = useLocation()
+
+  if (isLoading) {
+    return (
+      <section className="page">
+        <p>Loading...</p>
+      </section>
+    )
+  }
+
+  if (!session) {
+    const returnTo = `${location.pathname}${location.search}${location.hash}`
+    const params = new URLSearchParams()
+    if (returnTo) {
+      params.set('return_to', returnTo)
+    }
+    return <Navigate to={`/login?${params.toString()}`} replace />
+  }
+
+  return children
+}

--- a/frontend/src/services/ory.js
+++ b/frontend/src/services/ory.js
@@ -1,0 +1,12 @@
+import { Configuration, FrontendApi } from '@ory/client-fetch'
+
+const defaultBasePath = 'http://localhost:4000'
+const oryBasePath = import.meta.env.VITE_ORY_SDK_URL || defaultBasePath
+
+const configuration = new Configuration({
+  basePath: oryBasePath,
+  credentials: 'include',
+})
+
+export const ory = new FrontendApi(configuration)
+export { oryBasePath }


### PR DESCRIPTION
## Summary
- add an Ory SDK service and session provider powered by React Query
- render native Ory login and registration flows and protect private routes
- update styling and documentation for the new authentication experience
- fix the login and registration runtime error by extracting shared flow navigation logic and tolerating offline Ory responses

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e11af8c3bc83208b4368f73e4b371c