### PR TITLE
Fix CSS module imports for auth and info pages

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -1,4 +1,4 @@
-@import './main.scss';
+@use './main' as *;
 
 .app {
   min-height: 100vh;

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,4 +1,5 @@
 import { useAuth } from '../providers/useAuth.js'
+import styles from './DashboardPage.module.scss'
 
 export default function DashboardPage() {
   const { session } = useAuth()
@@ -6,8 +7,8 @@ export default function DashboardPage() {
 
   return (
     <section className={styles.page}>
-      <h1>Dashboard</h1>
-      <p>Track your registrations, team updates, and event announcements.</p>
+      <h1 className={styles.title}>Dashboard</h1>
+      <p className={styles.description}>Track your registrations, team updates, and event announcements.</p>
       {traits ? (
         <div className="card">
           <h2>Your profile</h2>

--- a/frontend/src/pages/DashboardPage.module.scss
+++ b/frontend/src/pages/DashboardPage.module.scss
@@ -11,13 +11,13 @@
   margin-right: auto;
 }
 
-h1 {
+.title {
   color: $color-primary-mid;
   font-size: 2rem;
   margin-bottom: 0.5em;
 }
 
-p {
+.description {
   color: $color-text;
   font-size: 1rem;
   margin-bottom: 0;
@@ -27,10 +27,10 @@ p {
   .page {
     padding: 1rem 0.5rem;
   }
-  h1 {
+  .title {
     font-size: 1.5rem;
   }
-  p {
+  .description {
     font-size: 0.95rem;
   }
 }

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -5,6 +5,7 @@ import OryFlowForm from '../components/OryFlowForm.jsx'
 import { ory } from '../services/ory.js'
 import { useAuth } from '../providers/useAuth.js'
 import { useOryFlowNavigation } from '../hooks/useOryFlowNavigation.js'
+import styles from './LoginPage.module.scss'
 
 const FLOW_RESET_STATUSES = new Set([403, 404, 410])
 
@@ -110,12 +111,14 @@ export default function LoginPage() {
 
   return (
     <section className={styles.page}>
-      <h1>Sign in</h1>
+      <h1 className={styles.title}>Sign in</h1>
       {formError ? <p className="flow-message flow-message--error">{formError}</p> : null}
       {isInitializing ? (
         <p>Loading login form...</p>
       ) : flow ? (
-        <OryFlowForm flow={flow} onSubmit={handleSubmit} isSubmitting={isSubmitting} />
+        <div className={styles.formWrapper}>
+          <OryFlowForm flow={flow} onSubmit={handleSubmit} isSubmitting={isSubmitting} />
+        </div>
       ) : (
         <div className="flow-retry">
           <p>We could not load the login form.</p>

--- a/frontend/src/pages/LoginPage.module.scss
+++ b/frontend/src/pages/LoginPage.module.scss
@@ -11,13 +11,13 @@
   margin-right: auto;
 }
 
-h1 {
+.title {
   color: $color-primary-mid;
   font-size: 2rem;
   margin-bottom: 1em;
 }
 
-.form {
+.formWrapper {
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
@@ -27,7 +27,7 @@ h1 {
   .page {
     padding: 1rem 0.5rem;
   }
-  h1 {
+  .title {
     font-size: 1.5rem;
   }
 }

--- a/frontend/src/pages/PublicInfoPage.jsx
+++ b/frontend/src/pages/PublicInfoPage.jsx
@@ -2,24 +2,24 @@ import styles from './PublicInfoPage.module.scss'
 
 export default function PublicInfoPage() {
   return (
-    <section className="page">
-      <h1>Młodzi Działają</h1>
-      <p>
+    <section className={styles.page}>
+      <h1 className={styles.title}>Młodzi Działają</h1>
+      <p className={styles.paragraph}>
         Młodzi Działają to cyfrowa platforma, która pomaga młodym wolontariuszom znaleźć inicjatywy w Krakowie,
         a organizacjom i szkołom sprawnie zarządzać ich zaangażowaniem.
       </p>
-      <p>
+      <p className={styles.paragraph}>
         Naszym celem jest stworzenie jednego, wiarygodnego miejsca współpracy między młodzieżą, organizacjami i koordynatorami,
         aby każdy wolontariusz mógł bezpiecznie rozwijać umiejętności i realnie wpływać na lokalną społeczność.
       </p>
-      <h2>Jakie wyzwania rozwiązujemy?</h2>
-      <ul>
-        <li>Ułatwiamy organizacjom docieranie z ofertami do młodych ludzi w atrakcyjnej i przejrzystej formie.</li>
-        <li>Zapewniamy szkołom narzędzia do formalnego prowadzenia i raportowania wolontariatu uczniów, w tym osób U18.</li>
-        <li>
+      <h2 className={styles.sectionTitle}>Jakie wyzwania rozwiązujemy?</h2>
+      <ul className={styles.list}>
+        <li className={styles.listItem}>Ułatwiamy organizacjom docieranie z ofertami do młodych ludzi w atrakcyjnej i przejrzystej formie.</li>
+        <li className={styles.listItem}>Zapewniamy szkołom narzędzia do formalnego prowadzenia i raportowania wolontariatu uczniów, w tym osób U18.</li>
+        <li className={styles.listItem}>
           Budujemy przestrzeń, która wspiera bezpieczną komunikację, zarządzanie zgodami oraz dokumentowanie efektów działań.
         </li>
-        <li>Pomagamy wolontariuszom odkrywać inicjatywy dopasowane do ich zainteresowań i budować portfolio aktywności.</li>
+        <li className={styles.listItem}>Pomagamy wolontariuszom odkrywać inicjatywy dopasowane do ich zainteresowań i budować portfolio aktywności.</li>
       </ul>
     </section>
   )

--- a/frontend/src/pages/PublicInfoPage.module.scss
+++ b/frontend/src/pages/PublicInfoPage.module.scss
@@ -11,26 +11,51 @@
   margin-right: auto;
 }
 
-h1 {
+.title {
   color: $color-accent;
   font-size: 2rem;
   margin-bottom: 0.5em;
 }
 
-p {
+.sectionTitle {
+  color: $color-primary-mid;
+  font-size: 1.4rem;
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.paragraph {
   color: $color-text;
   font-size: 1rem;
   margin-bottom: 0;
+}
+
+.list {
+  color: $color-text;
+  font-size: 1rem;
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.listItem {
+  line-height: 1.6;
 }
 
 @media (max-width: 600px) {
   .page {
     padding: 1rem 0.5rem;
   }
-  h1 {
+  .title {
     font-size: 1.5rem;
   }
-  p {
+  .sectionTitle {
+    font-size: 1.2rem;
+  }
+  .paragraph,
+  .list {
     font-size: 0.95rem;
   }
 }

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -5,6 +5,7 @@ import OryFlowForm from '../components/OryFlowForm.jsx'
 import { ory } from '../services/ory.js'
 import { useAuth } from '../providers/useAuth.js'
 import { useOryFlowNavigation } from '../hooks/useOryFlowNavigation.js'
+import styles from './RegisterPage.module.scss'
 
 const FLOW_RESET_STATUSES = new Set([403, 404, 410])
 
@@ -130,13 +131,15 @@ export default function RegisterPage() {
 
   return (
     <section className={styles.page}>
-      <h1>Create account</h1>
+      <h1 className={styles.title}>Create account</h1>
       {successMessage ? <p className="flow-message flow-message--success">{successMessage}</p> : null}
       {formError ? <p className="flow-message flow-message--error">{formError}</p> : null}
       {isInitializing ? (
         <p>Loading registration form...</p>
       ) : flow ? (
-        <OryFlowForm flow={flow} onSubmit={handleSubmit} isSubmitting={isSubmitting} />
+        <div className={styles.formWrapper}>
+          <OryFlowForm flow={flow} onSubmit={handleSubmit} isSubmitting={isSubmitting} />
+        </div>
       ) : (
         <div className="flow-retry">
           <p>We could not load the registration form.</p>

--- a/frontend/src/pages/RegisterPage.module.scss
+++ b/frontend/src/pages/RegisterPage.module.scss
@@ -11,13 +11,13 @@
   margin-right: auto;
 }
 
-h1 {
+.title {
   color: $color-primary-mid;
   font-size: 2rem;
   margin-bottom: 1em;
 }
 
-.form {
+.formWrapper {
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
@@ -27,7 +27,7 @@ h1 {
   .page {
     padding: 1rem 0.5rem;
   }
-  h1 {
+  .title {
     font-size: 1.5rem;
   }
 }

--- a/frontend/src/pages/VolunteerPanelPage.module.scss
+++ b/frontend/src/pages/VolunteerPanelPage.module.scss
@@ -1,5 +1,5 @@
 @use 'sass:color';
-@import '../main.scss';
+@use '../main' as *;
 
 .page {
   display: flex;
@@ -25,7 +25,8 @@
 }
 
 .avatar {
-  min-width: none;width: 64px;
+  min-width: 64px;
+  width: 64px;
   min-height: 64px;
   border-radius: 50%;
   background: linear-gradient(135deg, $color-primary-start, $color-primary-mid);


### PR DESCRIPTION
## Summary
- replace deprecated Sass @import usage with @use in shared and panel stylesheets
- wire up CSS modules for dashboard, login, register, and public info pages to avoid runtime errors
- refine layout classes for public information and auth forms

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1234fc68c83208e1cd13480c387b4