### PR TITLE
Refine organizer panel event listings and add detail page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import LoginPage from './pages/LoginPage.jsx'
 import RegisterPage from './pages/RegisterPage.jsx'
 import DashboardPage from './pages/DashboardPage.jsx'
 import OrganizerPanelPage from './pages/OrganizerPanelPage.jsx'
+import EventDetailsPage from './pages/EventDetailsPage.jsx'
 import VolunteerPanelPage from './pages/VolunteerPanelPage.jsx'
 import MapPage from './pages/MapPage.jsx'
 import { useAuth } from './providers/useAuth.js'
@@ -91,6 +92,7 @@ export default function App() {
             <Route path="/register" element={<RegisterPage />} />
             <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/organizer" element={<OrganizerPanelPage />} />
+            <Route path="/organizer/events/:eventId" element={<EventDetailsPage />} />
             <Route path="/volunteer" element={<VolunteerPanelPage />} />
             <Route path="/map" element={<MapPage />} />
           </Routes>

--- a/frontend/src/data/events.js
+++ b/frontend/src/data/events.js
@@ -1,0 +1,220 @@
+export const organizerProfile = {
+  name: 'Marta Zawadzka',
+  role: 'Koordynatorka programu',
+  phone: '+48 501 222 198',
+  email: 'marta.zawadzka@mlodzi-dzialaja.pl',
+  languages: ['polski', 'angielski'],
+  focusAreas: ['partycypacja młodzieży', 'partnerstwa lokalne'],
+}
+
+export const organizationProfile = {
+  name: 'Fundacja Młodzi Działają',
+  founded: 2012,
+  location: {
+    city: 'Warszawa',
+    venue: 'Centrum Aktywności Społecznej',
+    address: 'ul. Solidarności 27',
+  },
+  mission:
+    'Wspieramy młodych liderów w rozwijaniu projektów społecznych, łącząc edukację obywatelską z działaniem w terenie.',
+  programs: ['inkubator projektów', 'mikrogranty sąsiedzkie', 'akademia wolontariatu'],
+  website: 'https://mlodzi-dzialaja.pl',
+}
+
+export const events = [
+  {
+    id: 'civic-lab-2025',
+    name: 'Civic Lab 2025',
+    status: 'upcoming',
+    summary:
+      'Trzydniowe laboratorium projektowe, w trakcie którego młodzież tworzy rozwiązania dla wyzwań lokalnych.',
+    description:
+      'Civic Lab 2025 to intensywny proces projektowy, w którym zespoły młodzieżowe pracują z mentorami nad realnymi wyzwaniami miast. Uczestnicy przejdą przez etap diagnozy problemu, prototypowania rozwiązań oraz przygotowania prezentacji przed jury złożonym z przedstawicieli samorządów i organizacji społecznych.',
+    dates: { start: '2025-04-10', end: '2025-04-12' },
+    time: '09:30–17:30',
+    mainLocation: {
+      venue: 'Centrum Innowacji Młodych',
+      city: 'Warszawa',
+      address: 'ul. Przemian 4',
+    },
+    mapQuery: 'Centrum Innowacji Młodych, Warszawa',
+    focusAreas: ['innowacje społeczne', 'edukacja obywatelska'],
+    capacity: { participants: 80, volunteers: 28 },
+    registrations: 63,
+    tasks: [
+      {
+        id: 'civic-registration',
+        title: 'Rejestracja uczestników',
+        description: 'Przyjmowanie młodzieży i wydawanie pakietów startowych.',
+        location: 'Hol główny',
+        date: '2025-04-10',
+        timeFrom: '08:00',
+        timeTo: '10:30',
+        volunteerNeeds: {
+          minAge: 18,
+          skills: ['komunikacja interpersonalna', 'obsługa systemów rejestracyjnych'],
+          experience: 'Doświadczenie w pracy z młodzieżą mile widziane.',
+          additional: 'Potrzebne 4 osoby na poranną zmianę.',
+        },
+      },
+      {
+        id: 'civic-labsupport',
+        title: 'Wsparcie zespołów projektowych',
+        description: 'Moderowanie pracy warsztatowej i raportowanie postępów.',
+        location: 'Sala warsztatowa B',
+        date: '2025-04-10',
+        timeFrom: '10:00',
+        timeTo: '17:30',
+        volunteerNeeds: {
+          minAge: 19,
+          skills: ['facylitacja spotkań', 'notowanie wizualne'],
+          experience: 'Minimum jeden zrealizowany projekt społeczny.',
+          additional: '6 osób rotacyjnie w dwugodzinnych blokach.',
+        },
+      },
+      {
+        id: 'civic-media',
+        title: 'Zespół medialny',
+        description: 'Dokumentowanie wydarzenia, krótkie wywiady i relacje live.',
+        location: 'Strefa networkingowa',
+        date: '2025-04-11',
+        timeFrom: '09:00',
+        timeTo: '17:00',
+        volunteerNeeds: {
+          minAge: 17,
+          skills: ['fotografia', 'montaż krótkich materiałów wideo'],
+          experience: 'Portfolio lub link do wcześniejszych realizacji.',
+          additional: '5 osób, możliwość pracy w parach.',
+        },
+      },
+    ],
+  },
+  {
+    id: 'youth-forum-2024',
+    name: 'Youth Forum 2024',
+    status: 'completed',
+    summary:
+      'Ogólnopolskie forum młodych liderów z debatami, konsultacjami eksperckimi i targami organizacji.',
+    description:
+      'Youth Forum 2024 zebrało liderów młodzieżowych z całej Polski. W programie znalazły się debaty o przyszłości polityki młodzieżowej, sesje mentoringowe z ekspertami oraz targi organizacji wspierających młodych działaczy. Podsumowaniem wydarzenia była deklaracja współpracy podpisana przez 12 miast.',
+    dates: { start: '2024-09-19', end: '2024-09-21' },
+    time: '10:00–18:00',
+    mainLocation: {
+      venue: 'Hala Expo Łódź',
+      city: 'Łódź',
+      address: 'al. Politechniki 4',
+    },
+    mapQuery: 'Hala Expo Łódź',
+    focusAreas: ['polityka młodzieżowa', 'demokracja lokalna'],
+    capacity: { participants: 450, volunteers: 75 },
+    registrations: 418,
+    tasks: [
+      {
+        id: 'youth-stage',
+        title: 'Zarządzanie sceną główną',
+        description: 'Koordynowanie wejść prelegentów i obsługa zaplecza technicznego.',
+        location: 'Scena główna',
+        date: '2024-09-19',
+        timeFrom: '09:00',
+        timeTo: '19:00',
+        volunteerNeeds: {
+          minAge: 20,
+          skills: ['koordynacja zespołu', 'obsługa techniczna eventów'],
+          experience: 'Minimum jeden duży event w portfolio.',
+          additional: '8 osób pracujących w parach.',
+        },
+      },
+      {
+        id: 'youth-care',
+        title: 'Strefa dobrostanu',
+        description: 'Opieka nad strefą odpoczynku, prowadzenie krótkich aktywizacji.',
+        location: 'Strefa relaksu',
+        date: '2024-09-20',
+        timeFrom: '10:00',
+        timeTo: '18:00',
+        volunteerNeeds: {
+          minAge: 18,
+          skills: ['animacja czasu wolnego', 'pierwsza pomoc'],
+          experience: 'Certyfikat pierwszej pomocy lub szkolenie HSR.',
+          additional: '6 osób na dwie zmiany.',
+        },
+      },
+    ],
+  },
+  {
+    id: 'green-weekend-2025',
+    name: 'Green Weekend',
+    status: 'upcoming',
+    summary:
+      'Weekendowy cykl warsztatów ekologicznych i akcji sprzątania terenów zielonych.',
+    description:
+      'Green Weekend to rodzinny festiwal ekologiczny w przestrzeni parkowej. Zaplanowano warsztaty zero waste, wspólne sadzenie roślin, panele dyskusyjne z ekspertami oraz akcję sprzątania plaży. Celem wydarzenia jest zachęcenie mieszkańców do codziennych, proekologicznych nawyków.',
+    dates: { start: '2025-06-06', end: '2025-06-08' },
+    time: '08:30–16:30',
+    mainLocation: {
+      venue: 'Park Nadmorski',
+      city: 'Gdańsk',
+      address: 'ul. Brzegowa 5',
+    },
+    mapQuery: 'Park Nadmorski, Gdańsk',
+    focusAreas: ['ekologia', 'wolontariat rodzinny'],
+    capacity: { participants: 220, volunteers: 52 },
+    registrations: 188,
+    tasks: [
+      {
+        id: 'green-logistics',
+        title: 'Logistyka sprzętu',
+        description: 'Rozstawienie punktów warsztatowych i zabezpieczenie materiałów.',
+        location: 'Magazyn przy parku',
+        date: '2025-06-06',
+        timeFrom: '07:00',
+        timeTo: '10:00',
+        volunteerNeeds: {
+          minAge: 18,
+          skills: ['organizacja pracy', 'podstawy BHP'],
+          experience: 'Doświadczenie w pracy fizycznej w plenerze.',
+          additional: 'Potrzeba 10 osób, wymagane rękawice robocze.',
+        },
+      },
+      {
+        id: 'green-education',
+        title: 'Edukatorzy terenowi',
+        description: 'Prowadzenie stanowisk edukacyjnych i krótkich gier ekologicznych.',
+        location: 'Strefa warsztatowa',
+        date: '2025-06-07',
+        timeFrom: '09:00',
+        timeTo: '16:30',
+        volunteerNeeds: {
+          minAge: 17,
+          skills: ['praca z dziećmi', 'wiedza ekologiczna'],
+          experience: 'Minimum jeden wolontariat w podobnej tematyce.',
+          additional: '12 osób, krótkie szkolenie dzień wcześniej.',
+        },
+      },
+      {
+        id: 'green-cleanup',
+        title: 'Koordynacja sprzątania',
+        description: 'Przydzielanie ekipom sektorów i raportowanie postępów.',
+        location: 'Punkt zbiórki przy wejściu głównym',
+        date: '2025-06-08',
+        timeFrom: '08:30',
+        timeTo: '15:30',
+        volunteerNeeds: {
+          minAge: 18,
+          skills: ['zarządzanie zespołem', 'logistyka wydarzeń'],
+          experience: 'Preferowane doświadczenie w akcjach społecznych.',
+          additional: '8 osób, wymagane prawo jazdy kat. B dla dwóch osób.',
+        },
+      },
+    ],
+  },
+]
+
+export const findEventById = (eventId) => events.find((event) => event.id === eventId) ?? null
+
+export const formatDateRange = ({ start, end }) => {
+  if (start === end) {
+    return start
+  }
+  return `${start} – ${end}`
+}

--- a/frontend/src/pages/EventDetailsPage.jsx
+++ b/frontend/src/pages/EventDetailsPage.jsx
@@ -1,0 +1,193 @@
+import { Link, useParams } from 'react-router-dom'
+import styles from './EventDetailsPage.module.scss'
+import { findEventById, formatDateRange } from '../data/events.js'
+
+const buildMapSrc = (query) =>
+  `https://www.openstreetmap.org/export/embed.html?search=${encodeURIComponent(query)}&zoom=15`
+
+const buildMapLink = (query) =>
+  `https://www.openstreetmap.org/search?query=${encodeURIComponent(query)}`
+
+const buildTaskSummary = (task) => {
+  const primarySkills = task.volunteerNeeds.skills.slice(0, 2).join(', ')
+  return `Min. ${task.volunteerNeeds.minAge}+ • ${primarySkills || 'wolontariusze'}`
+}
+
+export default function EventDetailsPage() {
+  const { eventId } = useParams()
+  const event = findEventById(eventId)
+
+  if (!event) {
+    return (
+      <section className={styles.page}>
+        <nav className={styles.breadcrumbs}>
+          <Link to="/organizer">Panel organizatora</Link>
+        </nav>
+        <div className={styles.notFound}>
+          <h1>Nie znaleziono wydarzenia</h1>
+          <p>Sprawdź, czy adres jest poprawny, lub wróć do panelu organizatora.</p>
+          <Link className={styles.primaryLink} to="/organizer">
+            Wróć do listy wydarzeń
+          </Link>
+        </div>
+      </section>
+    )
+  }
+
+  const mapSrc = buildMapSrc(event.mapQuery)
+  const mapLink = buildMapLink(event.mapQuery)
+
+  return (
+    <section className={styles.page}>
+      <nav className={styles.breadcrumbs}>
+        <Link to="/organizer">Panel organizatora</Link>
+        <span aria-hidden="true">/</span>
+        <span>{event.name}</span>
+      </nav>
+
+      <header className={styles.hero}>
+        <div className={styles.heroIntro}>
+          <span className={styles.heroBadge}>{formatDateRange(event.dates)}</span>
+          <h1>{event.name}</h1>
+          <p>{event.summary}</p>
+        </div>
+        <dl className={styles.heroFacts}>
+          <div>
+            <dt>Godziny</dt>
+            <dd>{event.time}</dd>
+          </div>
+          <div>
+            <dt>Miasto</dt>
+            <dd>{event.mainLocation.city}</dd>
+          </div>
+          <div>
+            <dt>Zgłoszenia</dt>
+            <dd>
+              {event.registrations}/{event.capacity.participants}
+            </dd>
+          </div>
+          <div>
+            <dt>Wolontariusze</dt>
+            <dd>Potrzeba {event.capacity.volunteers} osób</dd>
+          </div>
+        </dl>
+      </header>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Informacje</h2>
+        </div>
+        <dl className={styles.infoGrid}>
+          <div>
+            <dt>Termin</dt>
+            <dd>{formatDateRange(event.dates)}</dd>
+          </div>
+          <div>
+            <dt>Zakres tematyczny</dt>
+            <dd>{event.focusAreas.join(', ')}</dd>
+          </div>
+          <div>
+            <dt>Limit uczestników</dt>
+            <dd>{event.capacity.participants}</dd>
+          </div>
+          <div>
+            <dt>Potrzebni wolontariusze</dt>
+            <dd>{event.capacity.volunteers}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Opis</h2>
+        </div>
+        <p className={styles.description}>{event.description}</p>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Lokalizacja</h2>
+        </div>
+        <dl className={styles.locationList}>
+          <div>
+            <dt>Miejsce</dt>
+            <dd>{event.mainLocation.venue}</dd>
+          </div>
+          <div>
+            <dt>Adres</dt>
+            <dd>{event.mainLocation.address}</dd>
+          </div>
+          <div>
+            <dt>Miasto</dt>
+            <dd>{event.mainLocation.city}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Mapka</h2>
+          <a className={styles.mapLink} href={mapLink} target="_blank" rel="noreferrer">
+            Otwórz w nowej karcie
+          </a>
+        </div>
+        <div className={styles.mapWrapper}>
+          <iframe title={`Mapa wydarzenia ${event.name}`} src={mapSrc} loading="lazy" />
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Zadania do zrealizowania</h2>
+        </div>
+        <div className={styles.tasksGrid}>
+          {event.tasks.map((task) => (
+            <article key={task.id} className={styles.taskCard}>
+              <header>
+                <h3>{task.title}</h3>
+                <p>{task.description}</p>
+              </header>
+              <dl className={styles.taskMeta}>
+                <div>
+                  <dt>Miejsce</dt>
+                  <dd>{task.location}</dd>
+                </div>
+                <div>
+                  <dt>Data</dt>
+                  <dd>{task.date}</dd>
+                </div>
+                <div>
+                  <dt>Godziny</dt>
+                  <dd>
+                    {task.timeFrom}–{task.timeTo}
+                  </dd>
+                </div>
+              </dl>
+              <details className={styles.taskDetails}>
+                <summary>{buildTaskSummary(task)}</summary>
+                <dl>
+                  <div>
+                    <dt>Minimalny wiek</dt>
+                    <dd>{task.volunteerNeeds.minAge} lat</dd>
+                  </div>
+                  <div>
+                    <dt>Umiejętności</dt>
+                    <dd>{task.volunteerNeeds.skills.join(', ')}</dd>
+                  </div>
+                  <div>
+                    <dt>Doświadczenie</dt>
+                    <dd>{task.volunteerNeeds.experience}</dd>
+                  </div>
+                  <div>
+                    <dt>Dodatkowe informacje</dt>
+                    <dd>{task.volunteerNeeds.additional}</dd>
+                  </div>
+                </dl>
+              </details>
+            </article>
+          ))}
+        </div>
+      </section>
+    </section>
+  )
+}

--- a/frontend/src/pages/EventDetailsPage.module.scss
+++ b/frontend/src/pages/EventDetailsPage.module.scss
@@ -1,0 +1,319 @@
+@use 'sass:color';
+@use '../main' as *;
+
+.page {
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: color.scale($color-text, $lightness: -10%);
+}
+
+.breadcrumbs a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.breadcrumbs a:hover,
+.breadcrumbs a:focus {
+  text-decoration: underline;
+}
+
+.notFound {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem;
+  background: $color-bg;
+  border-radius: $border-radius;
+  box-shadow: 0 12px 24px rgba($color-primary-mid, 0.08);
+}
+
+.notFound h1 {
+  margin: 0;
+}
+
+.notFound p {
+  margin: 0;
+  color: color.scale($color-text, $lightness: -5%);
+}
+
+.primaryLink {
+  align-self: flex-start;
+  padding: 0.75rem 1.5rem;
+  border-radius: $border-radius;
+  background: linear-gradient(135deg, $color-primary-start, $color-primary-end);
+  color: $color-bg;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryLink:hover,
+.primaryLink:focus {
+  transform: translateY(-1px);
+  box-shadow: $focus-shadow;
+}
+
+.hero {
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem;
+  background: linear-gradient(135deg, rgba($color-primary-start, 0.14), rgba($color-primary-end, 0.1));
+  border-radius: $border-radius;
+  box-shadow: 0 16px 28px rgba($color-primary-mid, 0.12);
+}
+
+.heroIntro {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.heroIntro h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.heroIntro p {
+  margin: 0;
+  font-size: 1rem;
+  color: color.scale($color-text, $lightness: -5%);
+}
+
+.heroBadge {
+  align-self: flex-start;
+  padding: 0.35rem 1rem;
+  border-radius: 999px;
+  background: rgba($color-secondary, 0.16);
+  color: color.scale($color-secondary, $lightness: -10%);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.heroFacts {
+  display: grid;
+  gap: 1rem;
+}
+
+.heroFacts div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.heroFacts dt {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: color.scale($color-text, $lightness: -20%);
+}
+
+.heroFacts dd {
+  margin: 0;
+  font-size: 1rem;
+  color: color.scale($color-text, $lightness: -5%);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.75rem;
+  background: $color-bg;
+  border-radius: $border-radius;
+  box-shadow: 0 10px 22px rgba($color-primary-mid, 0.08);
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.sectionHeader h2 {
+  margin: 0;
+}
+
+.infoGrid {
+  display: grid;
+  gap: 1rem;
+}
+
+.infoGrid div,
+.locationList div,
+.taskMeta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.infoGrid dt,
+.locationList dt,
+.taskMeta dt {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: color.scale($color-text, $lightness: -15%);
+}
+
+.infoGrid dd,
+.locationList dd,
+.taskMeta dd {
+  margin: 0;
+  font-size: 1rem;
+  color: color.scale($color-text, $lightness: -5%);
+}
+
+.description {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: color.scale($color-text, $lightness: -5%);
+}
+
+.locationList {
+  display: grid;
+  gap: 1rem;
+}
+
+.mapLink {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: $color-secondary;
+  text-decoration: none;
+}
+
+.mapLink:hover,
+.mapLink:focus {
+  text-decoration: underline;
+}
+
+.mapWrapper {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  border-radius: $border-radius;
+  overflow: hidden;
+  box-shadow: 0 12px 24px rgba($color-primary-mid, 0.1);
+}
+
+.mapWrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.tasksGrid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.taskCard {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-radius: $border-radius;
+  border: 1px solid rgba($color-primary-mid, 0.16);
+  background: rgba($color-bg, 0.98);
+}
+
+.taskCard header h3 {
+  margin: 0;
+}
+
+.taskCard header p {
+  margin: 0.5rem 0 0;
+  color: color.scale($color-text, $lightness: -5%);
+}
+
+.taskMeta {
+  display: grid;
+  gap: 1rem;
+}
+
+.taskDetails {
+  border-radius: $border-radius;
+  background: rgba($color-primary-start, 0.08);
+  padding: 1rem;
+}
+
+.taskDetails summary {
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.taskDetails summary:focus {
+  outline: none;
+}
+
+.taskDetails dl {
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.taskDetails dl div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.taskDetails dt {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: color.scale($color-text, $lightness: -15%);
+}
+
+.taskDetails dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: color.scale($color-text, $lightness: -5%);
+}
+
+@media (min-width: 720px) {
+  .hero {
+    grid-template-columns: 1fr auto;
+    align-items: center;
+  }
+
+  .heroFacts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .infoGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .locationList {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .taskMeta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  .tasksGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/frontend/src/pages/OrganizerPanelPage.jsx
+++ b/frontend/src/pages/OrganizerPanelPage.jsx
@@ -1,208 +1,12 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import styles from './OrganizerPanelPage.module.scss'
-
-const organizerProfile = {
-  name: 'Marta Zawadzka',
-  role: 'Koordynatorka programu',
-  phone: '+48 501 222 198',
-  email: 'marta.zawadzka@mlodzi-dzialaja.pl',
-  languages: ['polski', 'angielski'],
-  focusAreas: ['partycypacja młodzieży', 'partnerstwa lokalne'],
-}
-
-const organizationProfile = {
-  name: 'Fundacja Młodzi Działają',
-  founded: 2012,
-  location: {
-    city: 'Warszawa',
-    venue: 'Centrum Aktywności Społecznej',
-    address: 'ul. Solidarności 27',
-  },
-  mission:
-    'Wspieramy młodych liderów w rozwijaniu projektów społecznych, łącząc edukację obywatelską z działaniem w terenie.',
-  programs: ['inkubator projektów', 'mikrogranty sąsiedzkie', 'akademia wolontariatu'],
-  website: 'https://mlodzi-dzialaja.pl',
-}
-
-const events = [
-  {
-    id: 'civic-lab-2025',
-    name: 'Civic Lab 2025',
-    status: 'upcoming',
-    summary:
-      'Trzydniowe laboratorium projektowe, w trakcie którego młodzież tworzy rozwiązania dla wyzwań lokalnych.',
-    dates: { start: '2025-04-10', end: '2025-04-12' },
-    time: '09:30–17:30',
-    mainLocation: {
-      venue: 'Centrum Innowacji Młodych',
-      city: 'Warszawa',
-      address: 'ul. Przemian 4',
-    },
-    focusAreas: ['innowacje społeczne', 'edukacja obywatelska'],
-    capacity: { participants: 80, volunteers: 28 },
-    registrations: 63,
-    tasks: [
-      {
-        id: 'civic-registration',
-        title: 'Rejestracja uczestników',
-        description: 'Przyjmowanie młodzieży i wydawanie pakietów startowych.',
-        location: 'Hol główny',
-        date: '2025-04-10',
-        timeFrom: '08:00',
-        timeTo: '10:30',
-        volunteerNeeds: {
-          minAge: 18,
-          skills: ['komunikacja interpersonalna', 'obsługa systemów rejestracyjnych'],
-          experience: 'Doświadczenie w pracy z młodzieżą mile widziane.',
-          additional: 'Potrzebne 4 osoby na poranną zmianę.',
-        },
-      },
-      {
-        id: 'civic-labsupport',
-        title: 'Wsparcie zespołów projektowych',
-        description: 'Moderowanie pracy warsztatowej i raportowanie postępów.',
-        location: 'Sala warsztatowa B',
-        date: '2025-04-10',
-        timeFrom: '10:00',
-        timeTo: '17:30',
-        volunteerNeeds: {
-          minAge: 19,
-          skills: ['facylitacja spotkań', 'notowanie wizualne'],
-          experience: 'Minimum jeden zrealizowany projekt społeczny.',
-          additional: '6 osób rotacyjnie w dwugodzinnych blokach.',
-        },
-      },
-      {
-        id: 'civic-media',
-        title: 'Zespół medialny',
-        description: 'Dokumentowanie wydarzenia, krótkie wywiady i relacje live.',
-        location: 'Strefa networkingowa',
-        date: '2025-04-11',
-        timeFrom: '09:00',
-        timeTo: '17:00',
-        volunteerNeeds: {
-          minAge: 17,
-          skills: ['fotografia', 'montaż krótkich materiałów wideo'],
-          experience: 'Portfolio lub link do wcześniejszych realizacji.',
-          additional: '5 osób, możliwość pracy w parach.',
-        },
-      },
-    ],
-  },
-  {
-    id: 'youth-forum-2024',
-    name: 'Youth Forum 2024',
-    status: 'completed',
-    summary:
-      'Ogólnopolskie forum młodych liderów z debatami, konsultacjami eksperckimi i targami organizacji.',
-    dates: { start: '2024-09-19', end: '2024-09-21' },
-    time: '10:00–18:00',
-    mainLocation: {
-      venue: 'Hala Expo Łódź',
-      city: 'Łódź',
-      address: 'al. Politechniki 4',
-    },
-    focusAreas: ['polityka młodzieżowa', 'demokracja lokalna'],
-    capacity: { participants: 450, volunteers: 75 },
-    registrations: 418,
-    tasks: [
-      {
-        id: 'youth-stage',
-        title: 'Zarządzanie sceną główną',
-        description: 'Koordynowanie wejść prelegentów i obsługa zaplecza technicznego.',
-        location: 'Scena główna',
-        date: '2024-09-19',
-        timeFrom: '09:00',
-        timeTo: '19:00',
-        volunteerNeeds: {
-          minAge: 20,
-          skills: ['koordynacja zespołu', 'obsługa techniczna eventów'],
-          experience: 'Minimum jeden duży event w portfolio.',
-          additional: '8 osób pracujących w parach.',
-        },
-      },
-      {
-        id: 'youth-care',
-        title: 'Strefa dobrostanu',
-        description: 'Opieka nad strefą odpoczynku, prowadzenie krótkich aktywizacji.',
-        location: 'Strefa relaksu',
-        date: '2024-09-20',
-        timeFrom: '10:00',
-        timeTo: '18:00',
-        volunteerNeeds: {
-          minAge: 18,
-          skills: ['animacja czasu wolnego', 'pierwsza pomoc'],
-          experience: 'Certyfikat pierwszej pomocy lub szkolenie HSR.',
-          additional: '6 osób na dwie zmiany.',
-        },
-      },
-    ],
-  },
-  {
-    id: 'green-weekend-2025',
-    name: 'Green Weekend',
-    status: 'upcoming',
-    summary:
-      'Weekendowy cykl warsztatów ekologicznych i akcji sprzątania terenów zielonych.',
-    dates: { start: '2025-06-06', end: '2025-06-08' },
-    time: '08:30–16:30',
-    mainLocation: {
-      venue: 'Park Nadmorski',
-      city: 'Gdańsk',
-      address: 'ul. Brzegowa 5',
-    },
-    focusAreas: ['ekologia', 'wolontariat rodzinny'],
-    capacity: { participants: 220, volunteers: 52 },
-    registrations: 188,
-    tasks: [
-      {
-        id: 'green-logistics',
-        title: 'Logistyka sprzętu',
-        description: 'Rozstawienie punktów warsztatowych i zabezpieczenie materiałów.',
-        location: 'Magazyn przy parku',
-        date: '2025-06-06',
-        timeFrom: '07:00',
-        timeTo: '10:00',
-        volunteerNeeds: {
-          minAge: 18,
-          skills: ['organizacja pracy', 'podstawy BHP'],
-          experience: 'Doświadczenie w pracy fizycznej w plenerze.',
-          additional: 'Potrzeba 10 osób, wymagane rękawice robocze.',
-        },
-      },
-      {
-        id: 'green-education',
-        title: 'Edukatorzy terenowi',
-        description: 'Prowadzenie stanowisk edukacyjnych i krótkich gier ekologicznych.',
-        location: 'Strefa warsztatowa',
-        date: '2025-06-07',
-        timeFrom: '09:00',
-        timeTo: '16:30',
-        volunteerNeeds: {
-          minAge: 17,
-          skills: ['praca z dziećmi', 'wiedza ekologiczna'],
-          experience: 'Minimum jeden wolontariat w podobnej tematyce.',
-          additional: '12 osób, krótkie szkolenie dzień wcześniej.',
-        },
-      },
-      {
-        id: 'green-cleanup',
-        title: 'Koordynacja sprzątania',
-        description: 'Przydzielanie ekipom sektorów i raportowanie postępów.',
-        location: 'Punkt zbiórki przy wejściu głównym',
-        date: '2025-06-08',
-        timeFrom: '08:30',
-        timeTo: '15:30',
-        volunteerNeeds: {
-          minAge: 18,
-          skills: ['zarządzanie zespołem', 'logistyka wydarzeń'],
-          experience: 'Preferowane doświadczenie w akcjach społecznych.',
-          additional: '8 osób, wymagane prawo jazdy kat. B dla dwóch osób.',
-        },
-      },
-    ],
-  },
-]
+import {
+  events,
+  formatDateRange,
+  organizerProfile,
+  organizationProfile,
+} from '../data/events.js'
 
 const matchesSearch = (event, query) => {
   if (!query) {
@@ -212,6 +16,7 @@ const matchesSearch = (event, query) => {
     event.name,
     event.mainLocation.city,
     event.mainLocation.venue,
+    event.summary,
     ...event.focusAreas,
   ]
     .join(' ')
@@ -219,16 +24,8 @@ const matchesSearch = (event, query) => {
   return haystack.includes(query)
 }
 
-const formatDateRange = ({ start, end }) => {
-  if (start === end) {
-    return start
-  }
-  return `${start} – ${end}`
-}
-
 export default function OrganizerPanelPage() {
   const [searchValue, setSearchValue] = useState('')
-  const [selectedEventId, setSelectedEventId] = useState(events[0]?.id ?? null)
 
   const query = searchValue.trim().toLowerCase()
 
@@ -242,31 +39,12 @@ export default function OrganizerPanelPage() {
     [query],
   )
 
-  const visibleEvents = useMemo(
-    () => [...upcomingEvents, ...completedEvents],
-    [upcomingEvents, completedEvents],
-  )
-
-  useEffect(() => {
-    if (visibleEvents.length === 0) {
-      if (selectedEventId !== null) {
-        setSelectedEventId(null)
-      }
-      return
-    }
-    if (!selectedEventId || !visibleEvents.some((event) => event.id === selectedEventId)) {
-      setSelectedEventId(visibleEvents[0].id)
-    }
-  }, [visibleEvents, selectedEventId])
-
-  const selectedEvent = visibleEvents.find((event) => event.id === selectedEventId) ?? null
-
   return (
     <section className={styles.page}>
       <header className={styles.header}>
         <div>
           <h1>Panel organizatora</h1>
-          <p>Kompleksowy podgląd osoby kontaktowej, organizacji oraz wszystkich wydarzeń.</p>
+          <p>Wszystkie kluczowe informacje o zespole organizującym i planowanych inicjatywach.</p>
         </div>
         <div className={styles.searchBox}>
           <label htmlFor="event-search">Wyszukaj wydarzenie</label>
@@ -353,167 +131,88 @@ export default function OrganizerPanelPage() {
 
       <div className={styles.eventsLayout}>
         <section className={styles.card}>
-          <h2>Zarejestrowane wydarzenia</h2>
+          <div className={styles.cardHeader}>
+            <h2>Zarejestrowane wydarzenia</h2>
+            <span className={styles.counter}>{upcomingEvents.length}</span>
+          </div>
           {upcomingEvents.length === 0 ? (
             <p className={styles.emptyState}>Brak wydarzeń spełniających kryteria wyszukiwania.</p>
           ) : (
-            <ul className={styles.eventList}>
+            <ul className={styles.eventGrid}>
               {upcomingEvents.map((event) => (
                 <li key={event.id}>
-                  <button
-                    type="button"
-                    className={selectedEventId === event.id ? styles.eventButtonActive : styles.eventButton}
-                    onClick={() => setSelectedEventId(event.id)}
-                  >
-                    <span className={styles.eventName}>{event.name}</span>
-                    <span className={styles.eventMeta}>
-                      <span>{formatDateRange(event.dates)}</span>
-                      <span>
-                        {event.mainLocation.city} • {event.mainLocation.venue}
-                      </span>
-                    </span>
-                    <span className={styles.eventBadges}>
-                      <span>{event.focusAreas.join(' • ')}</span>
-                      <span>{event.registrations} zgłoszeń</span>
-                    </span>
-                  </button>
+                  <article className={styles.eventCard}>
+                    <header>
+                      <span className={styles.eventDate}>{formatDateRange(event.dates)}</span>
+                      <h3>{event.name}</h3>
+                    </header>
+                    <p className={styles.eventSummary}>{event.summary}</p>
+                    <dl className={styles.eventMeta}>
+                      <div>
+                        <dt>Miasto</dt>
+                        <dd>{event.mainLocation.city}</dd>
+                      </div>
+                      <div>
+                        <dt>Zgłoszenia</dt>
+                        <dd>
+                          {event.registrations}/{event.capacity.participants}
+                        </dd>
+                      </div>
+                    </dl>
+                    <div className={styles.eventFooter}>
+                      <span className={styles.eventTags}>{event.focusAreas.join(' • ')}</span>
+                      <Link className={styles.detailsLink} to={`/organizer/events/${event.id}`}>
+                        Szczegóły
+                      </Link>
+                    </div>
+                  </article>
                 </li>
               ))}
             </ul>
           )}
         </section>
         <section className={styles.card}>
-          <h2>Zrealizowane wydarzenia</h2>
+          <div className={styles.cardHeader}>
+            <h2>Zrealizowane wydarzenia</h2>
+            <span className={styles.counter}>{completedEvents.length}</span>
+          </div>
           {completedEvents.length === 0 ? (
             <p className={styles.emptyState}>Brak wydarzeń spełniających kryteria wyszukiwania.</p>
           ) : (
-            <ul className={styles.eventList}>
+            <ul className={styles.eventGrid}>
               {completedEvents.map((event) => (
                 <li key={event.id}>
-                  <button
-                    type="button"
-                    className={selectedEventId === event.id ? styles.eventButtonActive : styles.eventButton}
-                    onClick={() => setSelectedEventId(event.id)}
-                  >
-                    <span className={styles.eventName}>{event.name}</span>
-                    <span className={styles.eventMeta}>
-                      <span>{formatDateRange(event.dates)}</span>
-                      <span>
-                        {event.mainLocation.city} • {event.mainLocation.venue}
-                      </span>
-                    </span>
-                    <span className={styles.eventBadges}>
-                      <span>{event.focusAreas.join(' • ')}</span>
-                      <span>{event.registrations} zgłoszeń</span>
-                    </span>
-                  </button>
+                  <article className={styles.eventCard}>
+                    <header>
+                      <span className={styles.eventDate}>{formatDateRange(event.dates)}</span>
+                      <h3>{event.name}</h3>
+                    </header>
+                    <p className={styles.eventSummary}>{event.summary}</p>
+                    <dl className={styles.eventMeta}>
+                      <div>
+                        <dt>Miasto</dt>
+                        <dd>{event.mainLocation.city}</dd>
+                      </div>
+                      <div>
+                        <dt>Uczestnicy</dt>
+                        <dd>
+                          {event.registrations}/{event.capacity.participants}
+                        </dd>
+                      </div>
+                    </dl>
+                    <div className={styles.eventFooter}>
+                      <span className={styles.eventTags}>{event.focusAreas.join(' • ')}</span>
+                      <Link className={styles.detailsLink} to={`/organizer/events/${event.id}`}>
+                        Szczegóły
+                      </Link>
+                    </div>
+                  </article>
                 </li>
               ))}
             </ul>
           )}
         </section>
       </div>
-
-      <section className={styles.card}>
-        <h2>Szczegóły wydarzenia</h2>
-        {!selectedEvent ? (
-          <p className={styles.emptyState}>Wybierz wydarzenie, aby zobaczyć szczegóły.</p>
-        ) : (
-          <div className={styles.eventDetails}>
-            <div className={styles.eventSummary}>
-              <div>
-                <h3>{selectedEvent.name}</h3>
-                <p>{selectedEvent.summary}</p>
-              </div>
-              <dl className={styles.dataList}>
-                <div>
-                  <dt>Termin</dt>
-                  <dd>{formatDateRange(selectedEvent.dates)}</dd>
-                </div>
-                <div>
-                  <dt>Godziny</dt>
-                  <dd>{selectedEvent.time}</dd>
-                </div>
-                <div>
-                  <dt>Lokalizacja główna</dt>
-                  <dd>
-                    {selectedEvent.mainLocation.venue}
-                    <br />
-                    {selectedEvent.mainLocation.address}
-                    <br />
-                    {selectedEvent.mainLocation.city}
-                  </dd>
-                </div>
-                <div>
-                  <dt>Zakres tematyczny</dt>
-                  <dd>{selectedEvent.focusAreas.join(', ')}</dd>
-                </div>
-                <div>
-                  <dt>Uczestnicy</dt>
-                  <dd>
-                    {selectedEvent.registrations} potwierdzonych zgłoszeń<br />
-                    Limit {selectedEvent.capacity.participants} osób
-                  </dd>
-                </div>
-                <div>
-                  <dt>Wolontariusze</dt>
-                  <dd>Potrzeba {selectedEvent.capacity.volunteers} osób</dd>
-                </div>
-              </dl>
-            </div>
-            <div className={styles.tasks}>
-              <h3>Zadania do zrealizowania</h3>
-              <div className={styles.tasksGrid}>
-                {selectedEvent.tasks.map((task) => (
-                  <article key={task.id} className={styles.taskCard}>
-                    <header>
-                      <h4>{task.title}</h4>
-                      <p>{task.description}</p>
-                    </header>
-                    <dl className={styles.dataList}>
-                      <div>
-                        <dt>Lokalizacja</dt>
-                        <dd>{task.location}</dd>
-                      </div>
-                      <div>
-                        <dt>Data</dt>
-                        <dd>{task.date}</dd>
-                      </div>
-                      <div>
-                        <dt>Godziny</dt>
-                        <dd>
-                          {task.timeFrom}–{task.timeTo}
-                        </dd>
-                      </div>
-                    </dl>
-                    <div className={styles.volunteerNeeds}>
-                      <h5>Zapotrzebowanie na wolontariuszy</h5>
-                      <dl className={styles.dataList}>
-                        <div>
-                          <dt>Wiek od</dt>
-                          <dd>{task.volunteerNeeds.minAge} lat</dd>
-                        </div>
-                        <div>
-                          <dt>Umiejętności</dt>
-                          <dd>{task.volunteerNeeds.skills.join(', ')}</dd>
-                        </div>
-                        <div>
-                          <dt>Doświadczenie</dt>
-                          <dd>{task.volunteerNeeds.experience}</dd>
-                        </div>
-                        <div>
-                          <dt>Dodatkowe informacje</dt>
-                          <dd>{task.volunteerNeeds.additional}</dd>
-                        </div>
-                      </dl>
-                    </div>
-                  </article>
-                ))}
-              </div>
-            </div>
-          </div>
-        )}
-      </section>
     </section>
   )
 }

--- a/frontend/src/pages/OrganizerPanelPage.module.scss
+++ b/frontend/src/pages/OrganizerPanelPage.module.scss
@@ -68,11 +68,30 @@
   padding: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
 .card h2 {
   margin: 0;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.counter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  background: rgba($color-primary-mid, 0.12);
+  color: color.scale($color-primary-mid, $lightness: -5%);
 }
 
 .dataList {
@@ -105,62 +124,106 @@
   gap: 1.5rem;
 }
 
-.eventList {
+.eventGrid {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
-.eventButton {
-  width: 100%;
-  text-align: left;
-  padding: 1rem;
+.eventCard {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   border-radius: $border-radius;
-  border: 1px solid rgba($color-primary-mid, 0.15);
-  background: rgba($color-bg, 0.95);
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  border: 1px solid rgba($color-primary-mid, 0.14);
+  padding: 1.25rem;
+  background: rgba($color-bg, 0.98);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.eventButton:hover,
-.eventButton:focus {
-  outline: none;
-  border-color: $color-primary-mid;
-  box-shadow: $focus-shadow;
-  transform: translateY(-1px);
+.eventCard:hover,
+.eventCard:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba($color-primary-mid, 0.12);
 }
 
-.eventButtonActive {
-  @extend .eventButton;
-  border-color: $color-secondary;
-  box-shadow: 0 0 0 2px rgba($color-secondary, 0.25);
+.eventCard h3 {
+  margin: 0.25rem 0 0;
+  font-size: 1.1rem;
 }
 
-.eventName {
-  font-size: 1.05rem;
-  font-weight: 700;
+.eventDate {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba($color-secondary, 0.12);
+  color: color.scale($color-secondary, $lightness: -5%);
+  font-size: 0.85rem;
+  font-weight: 600;
 }
 
-.eventMeta {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+.eventSummary {
+  margin: 0;
   font-size: 0.95rem;
   color: color.scale($color-text, $lightness: -5%);
 }
 
-.eventBadges {
+.eventMeta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.eventMeta div {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  font-size: 0.85rem;
-  color: $color-secondary;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.eventMeta dt {
+  font-size: 0.75rem;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: color.scale($color-text, $lightness: -15%);
+}
+
+.eventMeta dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: color.scale($color-text, $lightness: -5%);
+}
+
+.eventFooter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.eventTags {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: $color-secondary;
+}
+
+.detailsLink {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  border-radius: $border-radius;
+  background: linear-gradient(135deg, $color-primary-start, $color-primary-end);
+  color: $color-bg;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.detailsLink:hover,
+.detailsLink:focus {
+  transform: translateY(-1px);
+  box-shadow: $focus-shadow;
 }
 
 .emptyState {
@@ -169,63 +232,8 @@
   color: color.scale($color-text, $lightness: -10%);
 }
 
-.eventDetails {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-}
-
-.eventSummary {
-  display: grid;
-  gap: 1.25rem;
-}
-
-.tasks {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.tasksGrid {
-  display: grid;
-  gap: 1.25rem;
-}
-
-.taskCard {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  border: 1px solid rgba($color-primary-mid, 0.12);
-  border-radius: $border-radius;
-  padding: 1.25rem;
-  background: rgba($color-bg, 0.98);
-  box-shadow: 0 6px 16px rgba($color-primary-mid, 0.06);
-}
-
-.taskCard h4 {
-  margin: 0;
-}
-
-.taskCard p {
-  margin: 0;
-}
-
-.volunteerNeeds {
-  background: rgba($color-primary-start, 0.05);
-  border-radius: $border-radius;
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.volunteerNeeds h5 {
-  margin: 0;
-  font-size: 1rem;
-}
-
 @media (min-width: 640px) {
-  .tasksGrid {
+  .eventGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -247,9 +255,9 @@
 }
 
 @media (min-width: 960px) {
-  .eventDetails {
-    display: grid;
-    grid-template-columns: 1.1fr 1fr;
-    gap: 2rem;
+  .eventFooter {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
   }
 }


### PR DESCRIPTION
## Summary
- replace the organizer event lists with compact cards that link to detailed views
- extract shared event and organization data to a dedicated module for reuse
- add a full event details page with structured sections and expandable volunteer requirements

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e12a667a4c83209a0af9e6d50c1b5c