### PR TITLE
Add events and actions volunteer matching page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import OrganizerPanelPage from './pages/OrganizerPanelPage.jsx'
 import EventDetailsPage from './pages/EventDetailsPage.jsx'
 import VolunteerPanelPage from './pages/VolunteerPanelPage.jsx'
 import MapPage from './pages/MapPage.jsx'
+import EventsAndActionsPage from './pages/EventsAndActionsPage.jsx'
 import { useAuth } from './providers/useAuth.js'
 
 const navigationItems = [
@@ -17,6 +18,7 @@ const navigationItems = [
   { to: '/dashboard', label: 'Dashboard' },
   { to: '/organizer', label: 'Organizer' },
   { to: '/volunteer', label: 'Volunteer' },
+  { to: '/events-actions', label: 'Wydarzenia i działania' },
   { to: '/map', label: 'Map' },
 ]
 
@@ -104,6 +106,7 @@ export default function App() {
             <Route path="/organizer" element={<OrganizerPanelPage />} />
             <Route path="/organizer/events/:eventId" element={<EventDetailsPage />} />
             <Route path="/volunteer" element={<VolunteerPanelPage />} />
+            <Route path="/events-actions" element={<EventsAndActionsPage />} />
             <Route path="/map" element={<MapPage />} />
           </Routes>
         </main>

--- a/frontend/src/pages/EventsAndActionsPage.jsx
+++ b/frontend/src/pages/EventsAndActionsPage.jsx
@@ -1,0 +1,386 @@
+import { useMemo, useState } from 'react'
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
+import 'leaflet/dist/leaflet.css'
+import L from 'leaflet'
+import styles from './EventsAndActionsPage.module.scss'
+import { events } from '../data/events.js'
+
+const markerIcon = new L.Icon({
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+  shadowSize: [41, 41],
+})
+
+const cityCoordinates = {
+  Warszawa: [52.2297, 21.0122],
+  'Łódź': [51.7592, 19.455],
+  'Gdańsk': [54.352, 18.6466],
+}
+
+const availabilityOptions = [
+  { value: 'weekday', label: 'Dni robocze' },
+  { value: 'weekend', label: 'Weekend' },
+  { value: 'evening', label: 'Popołudnia i wieczory' },
+]
+
+const initialFilters = {
+  city: '',
+  focusArea: '',
+  skill: '',
+  availability: '',
+  age: '',
+}
+
+const formatDate = (isoDate) => {
+  const date = new Date(isoDate)
+  return date.toLocaleDateString('pl-PL', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+const formatTimeRange = (from, to) => `${from} – ${to}`
+
+const calculateMatchScore = (demand, filters) => {
+  let score = 40
+  if (filters.city && demand.city === filters.city) {
+    score += 15
+  }
+  if (filters.focusArea && demand.focusAreas.includes(filters.focusArea)) {
+    score += 20
+  }
+  if (filters.skill && demand.volunteerNeeds.skills.includes(filters.skill)) {
+    score += 20
+  }
+  if (filters.availability) {
+    const isWeekend = demand.availability === 'weekend'
+    const isEvening = demand.availability === 'evening'
+    if (
+      (filters.availability === 'weekend' && isWeekend) ||
+      (filters.availability === 'weekday' && !isWeekend) ||
+      (filters.availability === 'evening' && isEvening)
+    ) {
+      score += 15
+    }
+  }
+  if (filters.age) {
+    const volunteerAge = Number(filters.age)
+    if (Number.isFinite(volunteerAge) && volunteerAge >= demand.volunteerNeeds.minAge) {
+      score += 10
+    }
+  }
+  return Math.min(score, 100)
+}
+
+const getAvailabilityTag = (date, timeFrom, timeTo) => {
+  const parsedDate = new Date(date)
+  const day = parsedDate.getDay()
+  const isWeekend = day === 0 || day === 6
+  const fromHour = Number(timeFrom.split(':')[0])
+  const toHour = Number(timeTo.split(':')[0])
+  if (isWeekend) {
+    return 'weekend'
+  }
+  if (fromHour >= 16 || toHour >= 18) {
+    return 'evening'
+  }
+  return 'weekday'
+}
+
+export default function EventsAndActionsPage() {
+  const [filters, setFilters] = useState(initialFilters)
+
+  const demands = useMemo(
+    () =>
+      events.flatMap((event) =>
+        event.tasks.map((task) => {
+          const availability = getAvailabilityTag(task.date, task.timeFrom, task.timeTo)
+          return {
+            id: task.id,
+            eventId: event.id,
+            eventName: event.name,
+            eventStatus: event.status,
+            city: event.mainLocation.city,
+            venue: event.mainLocation.venue,
+            address: event.mainLocation.address,
+            focusAreas: event.focusAreas,
+            summary: event.summary,
+            date: task.date,
+            timeFrom: task.timeFrom,
+            timeTo: task.timeTo,
+            taskTitle: task.title,
+            taskDescription: task.description,
+            volunteerNeeds: task.volunteerNeeds,
+            availability,
+          }
+        })
+      ),
+    []
+  )
+
+  const cities = useMemo(() => Array.from(new Set(events.map((event) => event.mainLocation.city))), [])
+  const focusAreas = useMemo(
+    () => Array.from(new Set(events.flatMap((event) => event.focusAreas))),
+    []
+  )
+  const skills = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          events.flatMap((event) =>
+            event.tasks.flatMap((task) => task.volunteerNeeds.skills)
+          )
+        )
+      ),
+    []
+  )
+
+  const filteredDemands = useMemo(() => {
+    return demands
+      .filter((demand) => {
+        if (filters.city && demand.city !== filters.city) {
+          return false
+        }
+        if (filters.focusArea && !demand.focusAreas.includes(filters.focusArea)) {
+          return false
+        }
+        if (filters.skill && !demand.volunteerNeeds.skills.includes(filters.skill)) {
+          return false
+        }
+        if (filters.availability) {
+          if (filters.availability === 'weekend' && demand.availability !== 'weekend') {
+            return false
+          }
+          if (filters.availability === 'weekday' && demand.availability === 'weekend') {
+            return false
+          }
+          if (filters.availability === 'evening' && demand.availability !== 'evening') {
+            return false
+          }
+        }
+        if (filters.age) {
+          const volunteerAge = Number(filters.age)
+          if (Number.isFinite(volunteerAge) && volunteerAge < demand.volunteerNeeds.minAge) {
+            return false
+          }
+        }
+        return true
+      })
+      .map((demand) => ({
+        ...demand,
+        matchScore: calculateMatchScore(demand, filters),
+      }))
+      .sort((a, b) => b.matchScore - a.matchScore)
+  }, [demands, filters])
+
+  const activeEvents = useMemo(() => {
+    const grouped = new Map()
+    filteredDemands.forEach((demand) => {
+      if (!grouped.has(demand.eventId)) {
+        grouped.set(demand.eventId, {
+          eventId: demand.eventId,
+          eventName: demand.eventName,
+          city: demand.city,
+          focusAreas: demand.focusAreas,
+          summary: demand.summary,
+          tasksCount: 0,
+        })
+      }
+      const current = grouped.get(demand.eventId)
+      current.tasksCount += 1
+    })
+    return Array.from(grouped.values())
+  }, [filteredDemands])
+
+  const handleFilterChange = (event) => {
+    const { name, value } = event.target
+    setFilters((current) => ({
+      ...current,
+      [name]: value,
+    }))
+  }
+
+  const resetFilters = () => {
+    setFilters(initialFilters)
+  }
+
+  const mapCenter = [52.0693, 19.4803]
+
+  return (
+    <section className={styles.page}>
+      <header className={styles.header}>
+        <span className={styles.eyebrow}>Wyszukiwarka akcji</span>
+        <h1>Wydarzenia i działania</h1>
+        <p>
+          Odkryj aktualne potrzeby wolontariuszy i wybierz zadania, które najlepiej pasują do Twoich
+          kompetencji, dostępności i obszarów zaangażowania.
+        </p>
+      </header>
+
+      <section className={styles.filters} aria-label="Filtry dopasowania">
+        <div className={styles.filterHeader}>
+          <h2>Doprecyzuj, czego szukasz</h2>
+          <button type="button" onClick={resetFilters} className={styles.resetButton}>
+            Wyczyść filtry
+          </button>
+        </div>
+        <div className={styles.filterGrid}>
+          <label className={styles.filterField}>
+            <span>Miasto</span>
+            <select name="city" value={filters.city} onChange={handleFilterChange}>
+              <option value="">Dowolne</option>
+              {cities.map((city) => (
+                <option key={city} value={city}>
+                  {city}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={styles.filterField}>
+            <span>Obszar tematyczny</span>
+            <select name="focusArea" value={filters.focusArea} onChange={handleFilterChange}>
+              <option value="">Dowolny</option>
+              {focusAreas.map((area) => (
+                <option key={area} value={area}>
+                  {area}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={styles.filterField}>
+            <span>Kluczowa umiejętność</span>
+            <select name="skill" value={filters.skill} onChange={handleFilterChange}>
+              <option value="">Dowolna</option>
+              {skills.map((skill) => (
+                <option key={skill} value={skill}>
+                  {skill}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={styles.filterField}>
+            <span>Dostępność</span>
+            <select name="availability" value={filters.availability} onChange={handleFilterChange}>
+              <option value="">Dowolna</option>
+              {availabilityOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={styles.filterField}>
+            <span>Twój wiek</span>
+            <input
+              type="number"
+              name="age"
+              min="15"
+              max="80"
+              value={filters.age}
+              onChange={handleFilterChange}
+              placeholder="np. 19"
+            />
+          </label>
+        </div>
+      </section>
+
+      <section className={styles.mapSection} aria-label="Mapa wydarzeń">
+        <div className={styles.mapHeader}>
+          <h2>Mapa aktywnych wydarzeń</h2>
+          <p>
+            Zobacz, gdzie aktualnie poszukiwane są osoby do wsparcia. Kliknij znacznik, aby poznać
+            liczbę dostępnych zadań.
+          </p>
+        </div>
+        <div className={styles.mapWrapper}>
+          <MapContainer center={mapCenter} zoom={6} scrollWheelZoom className={styles.map}>
+            <TileLayer
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            />
+            {activeEvents.map((event) => {
+              const position = cityCoordinates[event.city]
+              if (!position) {
+                return null
+              }
+              return (
+                <Marker key={event.eventId} position={position} icon={markerIcon}>
+                  <Popup>
+                    <strong>{event.eventName}</strong>
+                    <br />
+                    {event.city}
+                    <br />
+                    {event.tasksCount} zapotrzebowań
+                  </Popup>
+                </Marker>
+              )
+            })}
+          </MapContainer>
+        </div>
+      </section>
+
+      <section className={styles.results} aria-label="Lista dopasowanych zapotrzebowań">
+        <header className={styles.resultsHeader}>
+          <h2>Najlepsze dopasowania dla Ciebie</h2>
+          <span className={styles.resultCount}>{filteredDemands.length} dostępnych zadań</span>
+        </header>
+        <ul className={styles.resultsList}>
+          {filteredDemands.map((demand) => (
+            <li key={demand.id} className={styles.resultCard}>
+              <div className={styles.resultHeader}>
+                <div>
+                  <span className={styles.resultEvent}>{demand.eventName}</span>
+                  <h3>{demand.taskTitle}</h3>
+                </div>
+                <div className={styles.scoreBadge}>
+                  <span>Dopasowanie</span>
+                  <strong>{demand.matchScore}%</strong>
+                </div>
+              </div>
+              <div className={styles.resultMeta}>
+                <span>{demand.city}</span>
+                <span>{formatDate(demand.date)}</span>
+                <span>{formatTimeRange(demand.timeFrom, demand.timeTo)}</span>
+              </div>
+              <p className={styles.resultDescription}>{demand.taskDescription}</p>
+              <div className={styles.resultDetails}>
+                <div>
+                  <h4>Wymagane umiejętności</h4>
+                  <ul>
+                    {demand.volunteerNeeds.skills.map((skill) => (
+                      <li key={skill}>{skill}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <h4>Warunki</h4>
+                  <ul>
+                    <li>Minimalny wiek: {demand.volunteerNeeds.minAge} lat</li>
+                    <li>Doświadczenie: {demand.volunteerNeeds.experience}</li>
+                    <li>{demand.volunteerNeeds.additional}</li>
+                  </ul>
+                </div>
+              </div>
+              <footer className={styles.resultFooter}>
+                <span>
+                  {demand.venue}, {demand.address}
+                </span>
+                <button type="button">Zgłoś chęć udziału</button>
+              </footer>
+            </li>
+          ))}
+        </ul>
+        {filteredDemands.length === 0 ? (
+          <div className={styles.emptyState}>
+            <h3>Brak wyników</h3>
+            <p>Spróbuj poluzować kryteria wyszukiwania, aby zobaczyć więcej propozycji.</p>
+          </div>
+        ) : null}
+      </section>
+    </section>
+  )
+}

--- a/frontend/src/pages/EventsAndActionsPage.module.scss
+++ b/frontend/src/pages/EventsAndActionsPage.module.scss
@@ -1,0 +1,279 @@
+@use '../main' as *;
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: linear-gradient(135deg, rgba($color-primary-start, 0.15), rgba($color-secondary, 0.15));
+  padding: 1.75rem 1.5rem;
+  border-radius: $border-radius;
+  box-shadow: 0 12px 32px rgba($color-primary-mid, 0.08);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: $color-primary-mid;
+}
+
+.filters {
+  background: $color-bg;
+  border-radius: $border-radius;
+  padding: 1.5rem;
+  box-shadow: 0 10px 24px rgba($color-primary-mid, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.filterHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.resetButton {
+  align-self: flex-start;
+  border: 1px solid rgba($color-primary-mid, 0.25);
+  background: transparent;
+  color: $color-primary-mid;
+  font-weight: 600;
+  padding: 0.5rem 0.9rem;
+  border-radius: $border-radius;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.resetButton:hover,
+.resetButton:focus {
+  background: rgba($color-primary-mid, 0.12);
+  outline: none;
+}
+
+.filterGrid {
+  display: grid;
+  gap: 1rem;
+}
+
+.filterField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.filterField select,
+.filterField input {
+  padding: 0.7rem 0.8rem;
+  border-radius: $border-radius;
+  border: 1px solid rgba($color-primary-mid, 0.25);
+  background: $color-input-bg;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.mapSection {
+  background: $color-bg;
+  border-radius: $border-radius;
+  padding: 1.5rem;
+  box-shadow: 0 12px 28px rgba($color-primary-mid, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.mapHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mapWrapper {
+  position: relative;
+  width: 100%;
+  height: 360px;
+  border-radius: $border-radius;
+  overflow: hidden;
+}
+
+.map {
+  width: 100%;
+  height: 100%;
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.resultsHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.resultCount {
+  font-weight: 600;
+  color: $color-primary-mid;
+}
+
+.resultsList {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.resultCard {
+  background: $color-bg;
+  border-radius: $border-radius;
+  padding: 1.5rem;
+  box-shadow: 0 18px 36px rgba($color-primary-mid, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.resultHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.resultEvent {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba($color-primary-mid, 0.9);
+}
+
+.scoreBadge {
+  align-self: flex-start;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+  background: rgba($color-secondary, 0.12);
+  padding: 0.5rem 0.8rem;
+  border-radius: $border-radius;
+  color: $color-secondary;
+  font-weight: 600;
+}
+
+.scoreBadge strong {
+  font-size: 1.25rem;
+}
+
+.resultMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: rgba($color-text, 0.75);
+}
+
+.resultDescription {
+  margin: 0;
+}
+
+.resultDetails {
+  display: grid;
+  gap: 1rem;
+}
+
+.resultDetails h4 {
+  margin: 0 0 0.35rem 0;
+}
+
+.resultDetails ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.resultFooter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.resultFooter button {
+  align-self: flex-start;
+  background: linear-gradient(135deg, $color-primary-start, $color-secondary);
+  color: #fff;
+  border: none;
+  border-radius: $border-radius;
+  padding: 0.75rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.resultFooter button:hover,
+.resultFooter button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba($color-secondary, 0.25);
+  outline: none;
+}
+
+.emptyState {
+  background: $color-bg;
+  border-radius: $border-radius;
+  padding: 1.5rem;
+  text-align: center;
+  box-shadow: 0 12px 24px rgba($color-primary-mid, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (min-width: 640px) {
+  .filterGrid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .resultHeader {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .resultDetails {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .resultFooter {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 960px) {
+  .page {
+    gap: 2rem;
+  }
+
+  .filters,
+  .mapSection {
+    padding: 2rem;
+  }
+
+  .resultsList {
+    gap: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add the Wydarzenia i działania page with volunteer demand filters, scoring, and call to action
- show active locations on an interactive map tied to filtered results
- link the new search experience into the global navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e12c43817c8320bccef31816fa7aaf