### PR TITLE
Refine mobile layout spacing and typography

### DIFF
--- a/frontend/src/main.scss
+++ b/frontend/src/main.scss
@@ -21,7 +21,7 @@ body {
   background: $color-bg;
   color: $color-text;
   font-family: 'Inter', Arial, sans-serif;
-  font-size: 1rem;
+  font-size: 0.95rem;
   margin: 0;
   min-height: 100vh;
 }
@@ -34,28 +34,28 @@ h5,
 h6 {
   color: $color-text;
   font-weight: 700;
-  margin: 1.2em 0 0.6em 0;
-  line-height: 1.2;
+  margin: 0.9em 0 0.45em 0;
+  line-height: 1.1;
 }
 
 h1 {
-  font-size: 1.75rem;
+  font-size: 1.6rem;
 }
 
 h2 {
-  font-size: 1.4rem;
+  font-size: 1.35rem;
 }
 
 h3 {
-  font-size: 1.2rem;
+  font-size: 1.15rem;
 }
 
 h4 {
-  font-size: 1.1rem;
+  font-size: 1.05rem;
 }
 
 h5 {
-  font-size: 1rem;
+  font-size: 0.95rem;
 }
 
 h6 {
@@ -65,45 +65,47 @@ h6 {
 p,
 span {
   color: $color-text;
-  font-size: 1rem;
-  line-height: 1.6;
-  margin: 0 0 1em 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: 0 0 0.8em 0;
 }
 
 .app {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(180deg, rgba(43, 100, 169, 0.08), rgba(223, 72, 109, 0.08));
+  background: linear-gradient(180deg, rgba(43, 100, 169, 0.06), rgba(223, 72, 109, 0.06));
 }
 
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.25rem;
+  padding: 0.75rem 1rem;
   background: #fff;
   color: $color-primary-mid;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
-  position: relative;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 
   .brand {
     font-weight: 700;
-    font-size: 1.25rem;
+    font-size: 1.1rem;
     color: $color-primary-mid;
   }
 
   .menu-toggle {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
+    gap: 0.35rem;
     background: none;
     border: none;
-    font-size: 1.8rem;
+    font-size: 1.2rem;
     font-weight: 600;
     color: $color-primary-mid;
     cursor: pointer;
-    padding: 0.4rem 0.75rem;
+    padding: 0.35rem 0.6rem;
     border-radius: $border-radius;
     transition: background-color 0.2s;
 
@@ -120,13 +122,13 @@ span {
     position: fixed;
     top: 0;
     right: 0;
-    width: 100vw;
+    width: min(100vw, 360px);
     height: 100vh;
     background: #fff;
-    box-shadow: -4px 0 20px rgba(0, 0, 0, 0.08);
+    box-shadow: -4px 0 14px rgba(0, 0, 0, 0.06);
     display: flex;
     flex-direction: column;
-    padding: 2rem 1.5rem;
+    padding: 1.2rem 1rem;
     transform: translateX(100%);
     transition: transform 0.3s ease-in-out;
     z-index: 999;
@@ -139,7 +141,7 @@ span {
       color: $color-primary-mid;
       font-weight: 600;
       text-decoration: none;
-      padding: 0.75rem 0.5rem;
+      padding: 0.6rem 0.5rem;
       border-radius: $border-radius;
       transition: background-color 0.2s;
 
@@ -193,51 +195,19 @@ span {
 .account-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.25rem 0.75rem;
+  gap: 0.3rem;
+  padding: 0.2rem 0.55rem;
   border-radius: 999px;
-  background-color: rgba(255, 255, 255, 0.2);
-  color: #fff;
-  font-size: 0.85rem;
+  background-color: rgba(48, 145, 206, 0.15);
+  color: $color-primary-mid;
+  font-size: 0.75rem;
   font-weight: 600;
-}
-
-.menu-toggle {
-  align-self: flex-end;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  border-radius: $border-radius;
-  background: transparent;
-  color: #fff;
-  font-size: 0.95rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
-}
-
-.menu-toggle:hover,
-.menu-toggle:focus {
-  background-color: rgba(255, 255, 255, 0.12);
-  color: #fff;
-}
-
-.menu-toggle:focus {
-  outline: none;
-  box-shadow: $focus-shadow;
-}
-
-.menu-icon {
-  font-size: 1.25rem;
-  line-height: 1;
 }
 
 .nav {
   display: none;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4rem;
   width: 100%;
 }
 
@@ -247,10 +217,10 @@ span {
 
 .nav-link {
   display: block;
-  padding: 0.6rem 0.75rem;
+  padding: 0.55rem 0.65rem;
   border-radius: $border-radius;
-  background-color: rgba(255, 255, 255, 0.12);
-  color: #fff;
+  background-color: rgba($color-primary-mid, 0.08);
+  color: $color-primary-mid;
   font-weight: 600;
   text-decoration: none;
   border: none;
@@ -261,8 +231,8 @@ span {
 
 .nav-link:hover,
 .nav-link:focus {
-  background-color: rgba(255, 255, 255, 0.2);
-  color: #fff;
+  background-color: rgba($color-primary-mid, 0.12);
+  color: $color-primary-mid;
 }
 
 .nav-link:focus {
@@ -271,8 +241,8 @@ span {
 }
 
 .nav-link.active {
-  background-color: #fff;
-  color: $color-primary-start;
+  background-color: $color-primary-mid;
+  color: #fff;
 }
 
 .nav-link--button {
@@ -282,7 +252,7 @@ span {
 .content {
   flex: 1;
   width: 100%;
-  padding: 1.5rem 1rem 2.5rem;
+  padding: 1.25rem 0.75rem 1.75rem;
   display: flex;
   justify-content: center;
 }
@@ -291,7 +261,7 @@ span {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .form {
@@ -299,19 +269,20 @@ span {
   flex-direction: column;
 }
 
+
 .flow-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .flow-messages {
   list-style: none;
-  margin: 0 0 1rem 0;
+  margin: 0 0 0.75rem 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .flow-message {
@@ -334,8 +305,8 @@ span {
 .flow-field {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  margin-bottom: 1rem;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
 }
 
 .flow-field--checkbox {
@@ -366,53 +337,53 @@ span {
 
 .flow-actions {
   display: flex;
-  gap: 0.75rem;
-  margin-top: 0.5rem;
+  gap: 0.6rem;
+  margin-top: 0.35rem;
 }
 
 .flow-retry {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .card {
   background: #fff;
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(0, 0, 0, 0.06);
   border-radius: $border-radius;
-  padding: 1rem;
-  box-shadow: 0 10px 30px rgba(17, 34, 68, 0.08);
+  padding: 0.85rem;
+  box-shadow: 0 6px 18px rgba(17, 34, 68, 0.06);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .card-pre {
   margin: 0;
   background: $color-input-bg;
-  padding: 0.75rem;
+  padding: 0.6rem;
   border-radius: $border-radius;
   overflow-x: auto;
   font-size: 0.9rem;
-  line-height: 1.4;
+  line-height: 1.35;
 }
 
 label {
   font-weight: 600;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  margin-bottom: 1rem;
+  gap: 0.35rem;
+  margin-bottom: 0.85rem;
 }
 
 .form-controller {
   display: block;
   width: 100%;
-  padding: 0.7em 1em;
+  padding: 0.6em 0.85em;
   background: $color-input-bg;
   border: 1px solid $color-input-border;
   border-radius: $border-radius;
-  font-size: 1rem;
+  font-size: 0.95rem;
   color: $color-text;
   transition: border-color 0.2s, box-shadow 0.2s, background-color 0.2s;
   margin-bottom: 0;
@@ -434,10 +405,10 @@ label {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.4rem;
-  padding: 0.6em 1.2em;
+  gap: 0.35rem;
+  padding: 0.55em 1.05em;
   border-radius: $border-radius;
-  font-size: 1rem;
+  font-size: 0.95rem;
   font-weight: 600;
   text-align: center;
   cursor: pointer;
@@ -481,30 +452,30 @@ label {
 }
 
 .alert-success {
-  padding: 0.75rem 1rem;
+  padding: 0.6rem 0.85rem;
   border-radius: $border-radius;
-  background: rgba($color-green, 0.1);
+  background: rgba($color-green, 0.12);
   color: $color-green;
   font-weight: 600;
 }
 
 @media (min-width: 640px) {
   h1 {
-    font-size: 2rem;
+    font-size: 1.8rem;
   }
 
   h2 {
-    font-size: 1.5rem;
+    font-size: 1.45rem;
   }
 
   h3 {
-    font-size: 1.25rem;
+    font-size: 1.2rem;
   }
 
   .header {
     flex-direction: row;
     align-items: center;
-    gap: 1.5rem;
+    gap: 1rem;
   }
 
   .menu-toggle {
@@ -515,31 +486,28 @@ label {
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.6rem;
     width: auto;
   }
 
   .nav-link {
+    padding: 0.45rem 0.6rem;
     background-color: transparent;
   }
 
   .nav-link.active {
-    background-color: rgba(255, 255, 255, 0.2);
-    color: #fff;
+    background-color: rgba($color-primary-mid, 0.12);
+    color: $color-primary-mid;
   }
 
   .content {
-    padding: 2rem 2rem 3rem;
+    padding: 1.75rem 1.5rem 2.5rem;
   }
 }
 
 @media (min-width: 1024px) {
   .content {
-    padding: 3rem 3rem 4rem;
-  }
-
-  .page {
-    // max-width: 720px;
+    padding: 2rem 2.5rem 3rem;
   }
 }
 
@@ -547,5 +515,5 @@ label {
 .leaflet-pane,
 .leaflet-top,
 .leaflet-bottom {
-    z-index: 0 !important;
+  z-index: 0 !important;
 }

--- a/frontend/src/pages/DashboardPage.module.scss
+++ b/frontend/src/pages/DashboardPage.module.scss
@@ -3,34 +3,32 @@
 .page {
   background: $color-bg;
   border-radius: $border-radius;
-  box-shadow: 0 2px 12px rgba($color-primary-mid, 0.04);
-  padding: 2rem 1.5rem;
-  margin-bottom: 2rem;
-  max-width: 600px;
+  box-shadow: 0 6px 18px rgba($color-primary-mid, 0.08);
+  padding: 1.35rem 1rem;
+  margin-bottom: 1.5rem;
+  max-width: 480px;
   margin-left: auto;
   margin-right: auto;
 }
 
 .title {
   color: $color-primary-mid;
-  font-size: 2rem;
+  font-size: 1.6rem;
   margin-bottom: 0.5em;
 }
 
 .description {
   color: $color-text;
-  font-size: 1rem;
+  font-size: 0.95rem;
   margin-bottom: 0;
 }
 
 @media (max-width: 600px) {
   .page {
-    padding: 1rem 0.5rem;
+    padding: 1.1rem 0.75rem;
   }
+
   .title {
-    font-size: 1.5rem;
-  }
-  .description {
-    font-size: 0.95rem;
+    font-size: 1.45rem;
   }
 }

--- a/frontend/src/pages/EventDetailsPage.module.scss
+++ b/frontend/src/pages/EventDetailsPage.module.scss
@@ -4,17 +4,17 @@
 .page {
   width: 100%;
   max-width: 1100px;
-  margin: 0 auto 4rem;
+  margin: 0 auto 3rem;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.5rem;
 }
 
 .breadcrumbs {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.9rem;
+  gap: 0.4rem;
+  font-size: 0.85rem;
   color: color.scale($color-text, $lightness: -10%);
 }
 
@@ -31,11 +31,11 @@
 .notFound {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 2rem;
+  gap: 0.85rem;
+  padding: 1.2rem;
   background: $color-bg;
   border-radius: $border-radius;
-  box-shadow: 0 12px 24px rgba($color-primary-mid, 0.08);
+  box-shadow: 0 8px 20px rgba($color-primary-mid, 0.08);
 }
 
 .notFound h1 {
@@ -49,7 +49,7 @@
 
 .primaryLink {
   align-self: flex-start;
-  padding: 0.75rem 1.5rem;
+  padding: 0.6rem 1.25rem;
   border-radius: $border-radius;
   background: linear-gradient(135deg, $color-primary-start, $color-primary-end);
   color: $color-bg;
@@ -66,43 +66,45 @@
 
 .hero {
   display: grid;
-  gap: 1.5rem;
-  padding: 2rem;
-  background: linear-gradient(135deg, rgba($color-primary-start, 0.14), rgba($color-primary-end, 0.1));
+  gap: 1.1rem;
+  padding: 1.35rem;
+  background: linear-gradient(135deg, rgba($color-primary-start, 0.12), rgba($color-primary-end, 0.1));
   border-radius: $border-radius;
-  box-shadow: 0 16px 28px rgba($color-primary-mid, 0.12);
+  box-shadow: 0 12px 24px rgba($color-primary-mid, 0.1);
 }
 
 .heroIntro {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.8rem;
 }
 
 .heroIntro h1 {
   margin: 0;
-  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-size: clamp(1.6rem, 4vw, 2.1rem);
 }
 
 .heroIntro p {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.95rem;
   color: color.scale($color-text, $lightness: -5%);
+  line-height: 1.5;
 }
 
 .heroBadge {
   align-self: flex-start;
-  padding: 0.35rem 1rem;
+  padding: 0.3rem 0.85rem;
   border-radius: 999px;
-  background: rgba($color-secondary, 0.16);
+  background: rgba($color-secondary, 0.14);
   color: color.scale($color-secondary, $lightness: -10%);
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.03em;
+  font-size: 0.85rem;
 }
 
 .heroFacts {
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .heroFacts div {
@@ -112,34 +114,34 @@
 }
 
 .heroFacts dt {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   color: color.scale($color-text, $lightness: -20%);
 }
 
 .heroFacts dd {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.95rem;
   color: color.scale($color-text, $lightness: -5%);
 }
 
 .section {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-  padding: 1.75rem;
+  gap: 1rem;
+  padding: 1.35rem;
   background: $color-bg;
   border-radius: $border-radius;
-  box-shadow: 0 10px 22px rgba($color-primary-mid, 0.08);
+  box-shadow: 0 8px 20px rgba($color-primary-mid, 0.08);
 }
 
 .sectionHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .sectionHeader h2 {
@@ -148,7 +150,7 @@
 
 .infoGrid {
   display: grid;
-  gap: 1rem;
+  gap: 0.9rem;
 }
 
 .infoGrid div,
@@ -156,16 +158,16 @@
 .taskMeta div {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
 .infoGrid dt,
 .locationList dt,
 .taskMeta dt {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   color: color.scale($color-text, $lightness: -15%);
 }
 
@@ -173,20 +175,20 @@
 .locationList dd,
 .taskMeta dd {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.95rem;
   color: color.scale($color-text, $lightness: -5%);
 }
 
 .description {
   margin: 0;
-  font-size: 1rem;
-  line-height: 1.7;
+  font-size: 0.95rem;
+  line-height: 1.5;
   color: color.scale($color-text, $lightness: -5%);
 }
 
 .locationList {
   display: grid;
-  gap: 1rem;
+  gap: 0.9rem;
 }
 
 .mapLink {
@@ -207,7 +209,7 @@
   height: 0;
   border-radius: $border-radius;
   overflow: hidden;
-  box-shadow: 0 12px 24px rgba($color-primary-mid, 0.1);
+  box-shadow: 0 8px 20px rgba($color-primary-mid, 0.1);
 }
 
 .mapWrapper iframe {
@@ -221,14 +223,14 @@
 
 .tasksGrid {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.1rem;
 }
 
 .taskCard {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-  padding: 1.5rem;
+  gap: 0.9rem;
+  padding: 1.2rem;
   border-radius: $border-radius;
   border: 1px solid rgba($color-primary-mid, 0.16);
   background: rgba($color-bg, 0.98);
@@ -239,19 +241,21 @@
 }
 
 .taskCard header p {
-  margin: 0.5rem 0 0;
+  margin: 0.4rem 0 0;
   color: color.scale($color-text, $lightness: -5%);
+  font-size: 0.9rem;
+  line-height: 1.45;
 }
 
 .taskMeta {
   display: grid;
-  gap: 1rem;
+  gap: 0.9rem;
 }
 
 .taskDetails {
   border-radius: $border-radius;
   background: rgba($color-primary-start, 0.08);
-  padding: 1rem;
+  padding: 0.9rem;
 }
 
 .taskDetails summary {
@@ -264,28 +268,28 @@
 }
 
 .taskDetails dl {
-  margin: 1rem 0 0;
+  margin: 0.75rem 0 0;
   display: grid;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .taskDetails dl div {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
 .taskDetails dt {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   color: color.scale($color-text, $lightness: -15%);
 }
 
 .taskDetails dd {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   color: color.scale($color-text, $lightness: -5%);
 }
 

--- a/frontend/src/pages/EventsAndActionsPage.module.scss
+++ b/frontend/src/pages/EventsAndActionsPage.module.scss
@@ -3,41 +3,41 @@
 .page {
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 1.25rem;
 }
 
 .header {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  background: linear-gradient(135deg, rgba($color-primary-start, 0.15), rgba($color-secondary, 0.15));
-  padding: 1.75rem 1.5rem;
+  gap: 0.6rem;
+  background: linear-gradient(135deg, rgba($color-primary-start, 0.12), rgba($color-secondary, 0.12));
+  padding: 1.25rem 1.1rem;
   border-radius: $border-radius;
-  box-shadow: 0 12px 32px rgba($color-primary-mid, 0.08);
+  box-shadow: 0 8px 22px rgba($color-primary-mid, 0.08);
 }
 
 .eyebrow {
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.1em;
   font-weight: 600;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   color: $color-primary-mid;
 }
 
 .filters {
   background: $color-bg;
   border-radius: $border-radius;
-  padding: 1.5rem;
-  box-shadow: 0 10px 24px rgba($color-primary-mid, 0.08);
+  padding: 1.15rem 1rem;
+  box-shadow: 0 8px 20px rgba($color-primary-mid, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
 .filterHeader {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.55rem;
 }
 
 .resetButton {
@@ -46,7 +46,7 @@
   background: transparent;
   color: $color-primary-mid;
   font-weight: 600;
-  padding: 0.5rem 0.9rem;
+  padding: 0.45rem 0.8rem;
   border-radius: $border-radius;
   cursor: pointer;
   transition: background-color 0.2s ease;
@@ -60,46 +60,46 @@
 
 .filterGrid {
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .filterField {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  font-size: 0.95rem;
+  gap: 0.35rem;
+  font-size: 0.9rem;
 }
 
 .filterField select,
 .filterField input {
-  padding: 0.7rem 0.8rem;
+  padding: 0.55rem 0.75rem;
   border-radius: $border-radius;
   border: 1px solid rgba($color-primary-mid, 0.25);
   background: $color-input-bg;
-  font-size: 1rem;
+  font-size: 0.95rem;
   font-family: inherit;
 }
 
 .mapSection {
   background: $color-bg;
   border-radius: $border-radius;
-  padding: 1.5rem;
-  box-shadow: 0 12px 28px rgba($color-primary-mid, 0.08);
+  padding: 1.15rem 1rem;
+  box-shadow: 0 8px 22px rgba($color-primary-mid, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1rem;
 }
 
 .mapHeader {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.45rem;
 }
 
 .mapWrapper {
   position: relative;
   width: 100%;
-  height: 360px;
+  height: 280px;
   border-radius: $border-radius;
   overflow: hidden;
 }
@@ -112,24 +112,25 @@
 .results {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.15rem;
 }
 
 .resultsHeader {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.45rem;
 }
 
 .resultCount {
   font-weight: 600;
   color: $color-primary-mid;
+  font-size: 0.9rem;
 }
 
 .resultsList {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.1rem;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -138,25 +139,25 @@
 .resultCard {
   background: $color-bg;
   border-radius: $border-radius;
-  padding: 1.5rem;
-  box-shadow: 0 18px 36px rgba($color-primary-mid, 0.1);
+  padding: 1.1rem 1rem;
+  box-shadow: 0 10px 24px rgba($color-primary-mid, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .resultHeader {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .resultEvent {
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.75rem;
+  letter-spacing: 0.07em;
+  font-size: 0.7rem;
   font-weight: 600;
-  color: rgba($color-primary-mid, 0.9);
+  color: rgba($color-primary-mid, 0.85);
 }
 
 .scoreBadge {
@@ -164,33 +165,36 @@
   display: inline-flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.25rem;
-  background: rgba($color-secondary, 0.12);
-  padding: 0.5rem 0.8rem;
+  gap: 0.2rem;
+  background: rgba($color-secondary, 0.1);
+  padding: 0.45rem 0.75rem;
   border-radius: $border-radius;
   color: $color-secondary;
   font-weight: 600;
+  font-size: 0.85rem;
 }
 
 .scoreBadge strong {
-  font-size: 1.25rem;
+  font-size: 1.05rem;
 }
 
 .resultMeta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  font-size: 0.95rem;
+  gap: 0.6rem;
+  font-size: 0.9rem;
   color: rgba($color-text, 0.75);
 }
 
 .resultDescription {
   margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
 }
 
 .resultDetails {
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .resultDetails h4 {
@@ -199,16 +203,16 @@
 
 .resultDetails ul {
   margin: 0;
-  padding-left: 1.2rem;
+  padding-left: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
 .resultFooter {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .resultFooter button {
@@ -217,7 +221,7 @@
   color: #fff;
   border: none;
   border-radius: $border-radius;
-  padding: 0.75rem 1.25rem;
+  padding: 0.6rem 1.1rem;
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -233,12 +237,12 @@
 .emptyState {
   background: $color-bg;
   border-radius: $border-radius;
-  padding: 1.5rem;
+  padding: 1.15rem 1rem;
   text-align: center;
-  box-shadow: 0 12px 24px rgba($color-primary-mid, 0.08);
+  box-shadow: 0 8px 20px rgba($color-primary-mid, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.45rem;
 }
 
 @media (min-width: 640px) {
@@ -265,15 +269,15 @@
 
 @media (min-width: 960px) {
   .page {
-    gap: 2rem;
+    gap: 1.5rem;
   }
 
   .filters,
   .mapSection {
-    padding: 2rem;
+    padding: 1.5rem;
   }
 
   .resultsList {
-    gap: 2rem;
+    gap: 1.5rem;
   }
 }

--- a/frontend/src/pages/LoginPage.module.scss
+++ b/frontend/src/pages/LoginPage.module.scss
@@ -3,31 +3,32 @@
 .page {
   background: $color-bg;
   border-radius: $border-radius;
-  box-shadow: 0 2px 12px rgba($color-primary-mid, 0.04);
-  padding: 2rem 1.5rem;
-  margin-bottom: 2rem;
-  max-width: 400px;
+  box-shadow: 0 6px 18px rgba($color-primary-mid, 0.08);
+  padding: 1.35rem 1rem;
+  margin-bottom: 1.5rem;
+  max-width: 420px;
   margin-left: auto;
   margin-right: auto;
 }
 
 .title {
   color: $color-primary-mid;
-  font-size: 2rem;
-  margin-bottom: 1em;
+  font-size: 1.6rem;
+  margin-bottom: 0.75em;
 }
 
 .formWrapper {
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: 0.9rem;
 }
 
 @media (max-width: 600px) {
   .page {
-    padding: 1rem 0.5rem;
+    padding: 1.1rem 0.75rem;
   }
+
   .title {
-    font-size: 1.5rem;
+    font-size: 1.45rem;
   }
 }

--- a/frontend/src/pages/MapPage.module.scss
+++ b/frontend/src/pages/MapPage.module.scss
@@ -3,27 +3,27 @@
 .page {
   background: $color-bg;
   border-radius: $border-radius;
-  box-shadow: 0 2px 12px rgba($color-primary-mid, 0.04);
-  padding: 2rem 1.5rem;
-  margin-bottom: 2rem;
-  max-width: 700px;
+  box-shadow: 0 6px 18px rgba($color-primary-mid, 0.08);
+  padding: 1.35rem 1rem;
+  margin-bottom: 1.5rem;
+  max-width: 520px;
   margin-left: auto;
   margin-right: auto;
 }
 
 h1 {
   color: $color-primary-mid;
-  font-size: 2rem;
-  margin-bottom: 1em;
+  font-size: 1.6rem;
+  margin-bottom: 0.75em;
 }
 
 .map-wrapper {
   width: 100%;
-  height: 350px;
+  height: 280px;
   border-radius: $border-radius;
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba($color-primary-mid, 0.08);
-  margin-bottom: 1em;
+  box-shadow: 0 6px 18px rgba($color-primary-mid, 0.08);
+  margin-bottom: 0.75em;
 }
 
 .map {
@@ -33,11 +33,13 @@ h1 {
 
 @media (max-width: 600px) {
   .page {
-    padding: 1rem 0.5rem;
+    padding: 1.1rem 0.75rem;
   }
+
   h1 {
-    font-size: 1.5rem;
+    font-size: 1.45rem;
   }
+
   .map-wrapper {
     height: 220px;
   }

--- a/frontend/src/pages/OrganizerPanelPage.module.scss
+++ b/frontend/src/pages/OrganizerPanelPage.module.scss
@@ -7,17 +7,17 @@
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.5rem;
 }
 
 .header {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: 1.5rem;
-  background: linear-gradient(135deg, rgba($color-primary-start, 0.12), rgba($color-primary-end, 0.08));
+  gap: 1rem;
+  padding: 1.2rem;
+  background: linear-gradient(135deg, rgba($color-primary-start, 0.1), rgba($color-primary-end, 0.08));
   border-radius: $border-radius;
-  box-shadow: 0 12px 24px rgba($color-primary-mid, 0.08);
+  box-shadow: 0 10px 22px rgba($color-primary-mid, 0.08);
 }
 
 .header h1 {
@@ -33,20 +33,20 @@
 .searchBox {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .searchBox label {
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 .searchBox input {
-  padding: 0.75rem 1rem;
+  padding: 0.6rem 0.85rem;
   border-radius: $border-radius;
   border: 1px solid rgba($color-primary-mid, 0.2);
-  background-color: rgba($color-bg, 0.95);
-  font-size: 1rem;
+  background-color: rgba($color-bg, 0.97);
+  font-size: 0.95rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -58,17 +58,17 @@
 
 .infoGrid {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.1rem;
 }
 
 .card {
   background: $color-bg;
   border-radius: $border-radius;
   box-shadow: 0 8px 20px rgba($color-primary-mid, 0.08);
-  padding: 1.5rem;
+  padding: 1.15rem 1rem;
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 0.9rem;
 }
 
 .card h2 {
@@ -79,24 +79,25 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .counter {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 2.25rem;
-  padding: 0.25rem 0.75rem;
+  min-width: 2rem;
+  padding: 0.2rem 0.65rem;
   border-radius: 999px;
   font-weight: 700;
   background: rgba($color-primary-mid, 0.12);
   color: color.scale($color-primary-mid, $lightness: -5%);
+  font-size: 0.85rem;
 }
 
 .dataList {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .dataList div {
@@ -106,22 +107,22 @@
 }
 
 .dataList dt {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
   color: color.scale($color-text, $lightness: -10%);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
 }
 
 .dataList dd {
   margin: 0;
-  font-size: 1rem;
-  line-height: 1.5;
+  font-size: 0.95rem;
+  line-height: 1.45;
 }
 
 .eventsLayout {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.1rem;
 }
 
 .eventGrid {
@@ -129,16 +130,16 @@
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1rem;
+  gap: 0.9rem;
 }
 
 .eventCard {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.85rem;
   border-radius: $border-radius;
   border: 1px solid rgba($color-primary-mid, 0.14);
-  padding: 1.25rem;
+  padding: 1rem;
   background: rgba($color-bg, 0.98);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -151,30 +152,31 @@
 
 .eventCard h3 {
   margin: 0.25rem 0 0;
-  font-size: 1.1rem;
+  font-size: 1rem;
 }
 
 .eventDate {
   display: inline-flex;
   align-self: flex-start;
-  padding: 0.25rem 0.75rem;
+  padding: 0.25rem 0.65rem;
   border-radius: 999px;
   background: rgba($color-secondary, 0.12);
   color: color.scale($color-secondary, $lightness: -5%);
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
 }
 
 .eventSummary {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   color: color.scale($color-text, $lightness: -5%);
+  line-height: 1.45;
 }
 
 .eventMeta {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .eventMeta div {
@@ -184,34 +186,34 @@
 }
 
 .eventMeta dt {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   color: color.scale($color-text, $lightness: -15%);
 }
 
 .eventMeta dd {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   color: color.scale($color-text, $lightness: -5%);
 }
 
 .eventFooter {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .eventTags {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
   color: $color-secondary;
 }
 
 .detailsLink {
   align-self: flex-start;
-  padding: 0.5rem 1rem;
+  padding: 0.55rem 0.95rem;
   border-radius: $border-radius;
   background: linear-gradient(135deg, $color-primary-start, $color-primary-end);
   color: $color-bg;
@@ -228,7 +230,7 @@
 
 .emptyState {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   color: color.scale($color-text, $lightness: -10%);
 }
 

--- a/frontend/src/pages/PublicInfoPage.module.scss
+++ b/frontend/src/pages/PublicInfoPage.module.scss
@@ -3,59 +3,57 @@
 .page {
   background: $color-bg;
   border-radius: $border-radius;
-  box-shadow: 0 2px 12px rgba($color-primary-mid, 0.04);
-  padding: 2rem 1.5rem;
-  margin-bottom: 2rem;
-  max-width: 600px;
+  box-shadow: 0 6px 18px rgba($color-primary-mid, 0.08);
+  padding: 1.35rem 1rem;
+  margin-bottom: 1.5rem;
+  max-width: 460px;
   margin-left: auto;
   margin-right: auto;
 }
 
 .title {
   color: $color-accent;
-  font-size: 2rem;
-  margin-bottom: 0.5em;
+  font-size: 1.6rem;
+  margin-bottom: 0.4em;
 }
 
 .sectionTitle {
   color: $color-primary-mid;
-  font-size: 1.4rem;
-  margin-top: 1.5rem;
-  margin-bottom: 0.75rem;
+  font-size: 1.2rem;
+  margin-top: 1.1rem;
+  margin-bottom: 0.5rem;
 }
 
 .paragraph {
   color: $color-text;
-  font-size: 1rem;
+  font-size: 0.95rem;
   margin-bottom: 0;
 }
 
 .list {
   color: $color-text;
-  font-size: 1rem;
+  font-size: 0.95rem;
   margin: 0;
-  padding-left: 1.25rem;
+  padding-left: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .listItem {
-  line-height: 1.6;
+  line-height: 1.45;
 }
 
 @media (max-width: 600px) {
   .page {
-    padding: 1rem 0.5rem;
+    padding: 1.1rem 0.75rem;
   }
+
   .title {
-    font-size: 1.5rem;
+    font-size: 1.45rem;
   }
+
   .sectionTitle {
-    font-size: 1.2rem;
-  }
-  .paragraph,
-  .list {
-    font-size: 0.95rem;
+    font-size: 1.1rem;
   }
 }

--- a/frontend/src/pages/RegisterPage.module.scss
+++ b/frontend/src/pages/RegisterPage.module.scss
@@ -3,31 +3,32 @@
 .page {
   background: $color-bg;
   border-radius: $border-radius;
-  box-shadow: 0 2px 12px rgba($color-primary-mid, 0.04);
-  padding: 2rem 1.5rem;
-  margin-bottom: 2rem;
-  max-width: 400px;
+  box-shadow: 0 6px 18px rgba($color-primary-mid, 0.08);
+  padding: 1.35rem 1rem;
+  margin-bottom: 1.5rem;
+  max-width: 420px;
   margin-left: auto;
   margin-right: auto;
 }
 
 .title {
   color: $color-primary-mid;
-  font-size: 2rem;
-  margin-bottom: 1em;
+  font-size: 1.6rem;
+  margin-bottom: 0.75em;
 }
 
 .formWrapper {
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: 0.9rem;
 }
 
 @media (max-width: 600px) {
   .page {
-    padding: 1rem 0.5rem;
+    padding: 1.1rem 0.75rem;
   }
+
   .title {
-    font-size: 1.5rem;
+    font-size: 1.45rem;
   }
 }

--- a/frontend/src/pages/VolunteerPanelPage.module.scss
+++ b/frontend/src/pages/VolunteerPanelPage.module.scss
@@ -4,35 +4,35 @@
 .page {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.2rem;
   width: 100%;
 }
 
 .hero {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  background: linear-gradient(135deg, rgba($color-primary-start, 0.12), rgba($color-secondary, 0.12));
+  gap: 1rem;
+  background: linear-gradient(135deg, rgba($color-primary-start, 0.1), rgba($color-secondary, 0.12));
   border-radius: $border-radius;
-  padding: 1.5rem;
-  box-shadow: 0 12px 24px rgba($color-primary-mid, 0.08);
+  padding: 1.2rem;
+  box-shadow: 0 10px 22px rgba($color-primary-mid, 0.08);
 }
 
 .identity {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .avatar {
-  min-width: 64px;
-  width: 64px;
-  min-height: 64px;
+  min-width: 56px;
+  width: 56px;
+  min-height: 56px;
   border-radius: 50%;
   background: linear-gradient(135deg, $color-primary-start, $color-primary-mid);
   color: #fff;
   font-weight: 700;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -41,21 +41,21 @@
 .identityDetails {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
 .role {
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.07em;
   color: $color-primary-mid;
 }
 
 .actions {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .primaryAction,
@@ -64,7 +64,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.75rem 1.25rem;
+  padding: 0.65rem 1.1rem;
   border-radius: $border-radius;
   font-weight: 600;
   border: 1px solid transparent;
@@ -75,13 +75,13 @@
 .primaryAction {
   background: linear-gradient(135deg, $color-primary-start, $color-secondary);
   color: #fff;
-  box-shadow: 0 10px 20px rgba($color-secondary, 0.2);
+  box-shadow: 0 8px 18px rgba($color-secondary, 0.18);
 }
 
 .primaryAction:hover,
 .primaryAction:focus {
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba($color-secondary, 0.25);
+  box-shadow: 0 10px 22px rgba($color-secondary, 0.22);
   outline: none;
 }
 
@@ -93,63 +93,63 @@
 
 .secondaryAction:hover,
 .secondaryAction:focus {
-  background: rgba($color-primary-mid, 0.2);
+  background: rgba($color-primary-mid, 0.18);
   outline: none;
 }
 
 .metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.85rem;
 }
 
 .metric {
   background: $color-bg;
   border-radius: $border-radius;
-  padding: 1.25rem 1rem;
-  box-shadow: 0 6px 18px rgba($color-primary-mid, 0.06);
+  padding: 1.1rem 0.9rem;
+  box-shadow: 0 6px 16px rgba($color-primary-mid, 0.06);
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
 .metricValue {
-  font-size: 1.5rem;
+  font-size: 1.35rem;
   font-weight: 700;
   color: $color-primary-start;
 }
 
 .metricLabel {
-  font-size: 0.95rem;
+  font-size: 0.85rem;
   color: color.adjust($color-text, $lightness: -10%);
 }
 
 .sections {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.1rem;
 }
 
 .mainColumn,
 .sideColumn {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.1rem;
 }
 
 .card {
   background: $color-bg;
   border-radius: $border-radius;
-  padding: 1.5rem;
-  box-shadow: 0 10px 24px rgba($color-primary-mid, 0.06);
+  padding: 1.15rem 1rem;
+  box-shadow: 0 8px 20px rgba($color-primary-mid, 0.06);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.45rem;
   padding: 0;
   margin: 0;
   list-style: none;
@@ -158,21 +158,21 @@
 .tags li {
   background: rgba($color-accent, 0.15);
   color: color.adjust($color-secondary, $lightness: -10%);
-  padding: 0.45rem 0.75rem;
+  padding: 0.4rem 0.7rem;
   border-radius: 999px;
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
 }
 
 .detailGrid {
   display: grid;
-  gap: 1.25rem;
+  gap: 1rem;
 }
 
 .detailGrid div {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
 .shiftList,
@@ -183,14 +183,14 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.9rem;
 }
 
 .shiftItem {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  padding-bottom: 1rem;
+  gap: 0.3rem;
+  padding-bottom: 0.75rem;
   border-bottom: 1px solid rgba($color-primary-mid, 0.1);
 }
 
@@ -202,29 +202,29 @@
 .shiftHeader {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
 .shiftHeader h3 {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 1rem;
 }
 
 .shiftStatus {
   align-self: flex-start;
-  padding: 0.25rem 0.6rem;
+  padding: 0.2rem 0.55rem;
   border-radius: 999px;
-  background: rgba($color-green, 0.1);
+  background: rgba($color-green, 0.12);
   color: $color-green;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
 }
 
 .shiftMeta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  font-size: 0.95rem;
+  gap: 0.6rem;
+  font-size: 0.9rem;
   color: color.adjust($color-text, $lightness: -5%);
 }
 
@@ -234,14 +234,14 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1rem;
   position: relative;
 }
 
 .timeline::before {
   content: '';
   position: absolute;
-  left: 0.6rem;
+  left: 0.5rem;
   top: 0.25rem;
   bottom: 0.25rem;
   width: 2px;
@@ -251,41 +251,41 @@
 .timelineItem {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 1rem;
+  gap: 0.75rem;
   position: relative;
-  padding-left: 1.5rem;
+  padding-left: 1.25rem;
 }
 
 .timelineItem::before {
   content: '';
   position: absolute;
-  left: 0.2rem;
-  top: 0.4rem;
-  width: 0.8rem;
-  height: 0.8rem;
+  left: 0.15rem;
+  top: 0.35rem;
+  width: 0.65rem;
+  height: 0.65rem;
   border-radius: 50%;
   background: $color-primary-start;
-  box-shadow: 0 0 0 4px rgba($color-primary-start, 0.15);
+  box-shadow: 0 0 0 3px rgba($color-primary-start, 0.15);
 }
 
 .timelineDate {
   font-weight: 600;
   color: color.adjust($color-text, $lightness: -10%);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
 }
 
 .skillItem {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
+  gap: 0.85rem;
+  padding: 0.65rem 0.9rem;
   border-radius: $border-radius;
   background: rgba($color-primary-mid, 0.08);
 }
 
 .skillLevel {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
   color: $color-primary-mid;
 }
@@ -298,13 +298,13 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .definitionList div {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
 a {
@@ -322,13 +322,13 @@ a:focus {
   background: rgba($color-primary-start, 0.1);
   color: $color-primary-start;
   border-color: rgba($color-primary-start, 0.2);
-  padding-left: 1rem;
-  padding-right: 1rem;
+  padding-left: 0.9rem;
+  padding-right: 0.9rem;
 }
 
 .linkButton:hover,
 .linkButton:focus {
-  background: rgba($color-primary-start, 0.2);
+  background: rgba($color-primary-start, 0.18);
   outline: none;
 }
 
@@ -337,6 +337,7 @@ a:focus {
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    gap: 1.5rem;
   }
 
   .actions {
@@ -344,7 +345,7 @@ a:focus {
   }
 
   .sections {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 360px);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 340px);
   }
 
   .detailGrid {
@@ -354,14 +355,14 @@ a:focus {
 
 @media (min-width: 1024px) {
   .hero {
-    padding: 2rem;
+    padding: 1.6rem;
   }
 
   .metric {
-    padding: 1.5rem;
+    padding: 1.2rem;
   }
 
   .card {
-    padding: 2rem;
+    padding: 1.4rem;
   }
 }


### PR DESCRIPTION
## Summary
- tighten global typography, header styling, and shared components to present a denser mobile-first layout
- compact public info, auth, dashboard, and map views with reduced padding and tighter typography
- refresh organizer, volunteer, and events panels with lighter shadows, smaller badges, and condensed grids for an app-like feel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e12e67fa3083208b6fe14ad3cda6d0