### PR TITLE
Fix transparent header and navigation on events page

### DIFF
--- a/frontend/src/main.scss
+++ b/frontend/src/main.scss
@@ -82,12 +82,17 @@ span {
   align-items: center;
   justify-content: space-between;
   padding: 0.75rem 1rem;
-  background: #fff;
+  background: rgba($color-bg, 0.96);
   color: $color-primary-mid;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
   position: sticky;
   top: 0;
   z-index: 10;
+  border-bottom: 1px solid rgba($color-primary-mid, 0.08);
+
+  @supports (backdrop-filter: blur(8px)) {
+    backdrop-filter: blur(8px);
+  }
 
   .brand {
     font-weight: 700;
@@ -168,12 +173,15 @@ span {
       flex-direction: row;
       gap: 1rem;
       box-shadow: none;
-      background: transparent;
-      padding: 0;
+      background: rgba($color-bg, 0.96);
+      padding: 0.35rem 0.5rem;
       display: flex;
       justify-content: flex-end;
+      border-radius: $border-radius;
+      border: 1px solid rgba($color-primary-mid, 0.08);
 
       .nav-link {
+        background: transparent;
         color: $color-primary-mid;
         padding: 0.4rem 0.6rem;
         font-weight: 500;
@@ -184,7 +192,7 @@ span {
         }
 
         &:hover {
-          background: rgba($color-primary-mid, 0.05);
+          background: rgba($color-primary-mid, 0.08);
         }
       }
     }

--- a/frontend/src/pages/EventsAndActionsPage.module.scss
+++ b/frontend/src/pages/EventsAndActionsPage.module.scss
@@ -10,10 +10,11 @@
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
-  background: linear-gradient(135deg, rgba($color-primary-start, 0.12), rgba($color-secondary, 0.12));
+  background: linear-gradient(135deg, rgba($color-primary-start, 0.18), rgba($color-secondary, 0.16));
   padding: 1.25rem 1.1rem;
   border-radius: $border-radius;
   box-shadow: 0 8px 22px rgba($color-primary-mid, 0.08);
+  backdrop-filter: blur(6px);
 }
 
 .eyebrow {


### PR DESCRIPTION
## Summary
- ensure the global header and desktop navigation keep an opaque background and light border so content no longer shows through
- strengthen the events & actions page hero background for better contrast with the sticky header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e13767e1288320a2d7fd437926c529