### PR TITLE
Add organization entity and organizer API

### DIFF
--- a/backend/HackYeah2025.Backend/HackYeah2025/Features/OrganizerController.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Features/OrganizerController.cs
@@ -1,15 +1,29 @@
-﻿using Microsoft.AspNetCore.Http;
+using HackYeah2025.Infrastructure.Models;
 using Microsoft.AspNetCore.Mvc;
 
-namespace HackYeah2025.Features
+namespace HackYeah2025.Features;
+
+[Route("api/[controller]")]
+[ApiController]
+public class OrganizerController : ControllerBase
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class OrganizerController : ControllerBase
+    private readonly IOrganizerService _organizerService;
+
+    public OrganizerController(IOrganizerService organizerService)
     {
-        public OrganizerController()
+        _organizerService = organizerService;
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<Organization>> Get(Guid id, CancellationToken cancellationToken)
+    {
+        Organization? organization = await _organizerService.GetByIdAsync(id, cancellationToken);
+
+        if (organization is null)
         {
-            
+            return NotFound();
         }
+
+        return Ok(organization);
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Features/OrganizerService.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Features/OrganizerService.cs
@@ -1,0 +1,27 @@
+using HackYeah2025.Infrastructure;
+using HackYeah2025.Infrastructure.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace HackYeah2025.Features;
+
+public interface IOrganizerService
+{
+    Task<Organization?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+}
+
+public class OrganizerService : IOrganizerService
+{
+    private readonly HackYeahDbContext _dbContext;
+
+    public OrganizerService(HackYeahDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<Organization?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.Organizations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
+    }
+}

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/HackYeahDbContext.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/HackYeahDbContext.cs
@@ -1,4 +1,4 @@
-﻿using HackYeah2025.Infrastructure.Models;
+using HackYeah2025.Infrastructure.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace HackYeah2025.Infrastructure;
@@ -6,16 +6,17 @@ namespace HackYeah2025.Infrastructure;
 public sealed class HackYeahDbContext : DbContext
 {
     public DbSet<Event> Events { get; set; }
+    public DbSet<Organization> Organizations { get; set; }
 
-    public HackYeahDbContext(DbContextOptions<HackYeahDbContext> options) : base(options) 
-    { 
-    
+    public HackYeahDbContext(DbContextOptions<HackYeahDbContext> options) : base(options)
+    {
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        
+
         modelBuilder.ApplyConfiguration(new DbEventEntityTypeConfiguration());
+        modelBuilder.ApplyConfiguration(new DbOrganizationEntityTypeConfiguration());
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Organization.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Organization.cs
@@ -1,7 +1,42 @@
-﻿namespace HackYeah2025.Infrastructure.Models
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HackYeah2025.Infrastructure.Models;
+
+public class Organization
 {
-    public class Organization
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public int FoundedYear { get; set; }
+    public string Location { get; set; }
+    public string Programs { get; set; }
+    public string Mission { get; set; }
+    public string Website { get; set; }
+}
+
+public class DbOrganizationEntityTypeConfiguration : IEntityTypeConfiguration<Organization>
+{
+    public void Configure(EntityTypeBuilder<Organization> builder)
     {
-        public Guid Id { get; set; }
+        builder.HasKey(o => o.Id);
+        builder.Property(o => o.Name).IsRequired().HasMaxLength(256);
+        builder.Property(o => o.FoundedYear).IsRequired();
+        builder.Property(o => o.Location).IsRequired().HasMaxLength(512);
+        builder.Property(o => o.Programs).IsRequired().HasMaxLength(1024);
+        builder.Property(o => o.Mission).IsRequired().HasMaxLength(1024);
+        builder.Property(o => o.Website).IsRequired().HasMaxLength(256);
+
+        builder.HasData(
+            new Organization
+            {
+                Id = Guid.Parse("5d1f3c76-7a10-4fb4-a4a1-0d5710a98b72"),
+                Name = "Fundacja Młodzi Działają",
+                FoundedYear = 2012,
+                Location = "Centrum Aktywności Społecznej\nul. Solidarności 27\nWarszawa",
+                Programs = "inkubator projektów, mikrogranty sąsiedzkie, akademia wolontariatu",
+                Mission = "Wspieramy młodych liderów w rozwijaniu projektów społecznych, łącząc edukację obywatelską z działaniem w terenie.",
+                Website = "https://mlodzi-dzialaja.pl"
+            }
+        );
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Program.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Program.cs
@@ -1,3 +1,4 @@
+using HackYeah2025.Features;
 using HackYeah2025.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,6 +11,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddDbContext<HackYeahDbContext>(o =>
     o.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection"))
 );
+builder.Services.AddScoped<IOrganizerService, OrganizerService>();
 
 WebApplication app = builder.Build();
 


### PR DESCRIPTION
## Summary
- add the organization entity configuration and seed the initial organization data
- register the organizer service and expose the GET endpoint for fetching an organization by id

## Testing
- `dotnet build` *(fails: `dotnet` command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e14b711b1c8320bdc6869b7c9887fa