### PR TITLE
Add organizer entity and API endpoint

### DIFF
--- a/backend/HackYeah2025.Backend/HackYeah2025/Features/OrganizerController.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Features/OrganizerController.cs
@@ -15,15 +15,15 @@ public class OrganizerController : ControllerBase
     }
 
     [HttpGet("{id:guid}")]
-    public async Task<ActionResult<Organization>> Get(Guid id, CancellationToken cancellationToken)
+    public async Task<ActionResult<Organizer>> Get(Guid id, CancellationToken cancellationToken)
     {
-        Organization? organization = await _organizerService.GetByIdAsync(id, cancellationToken);
+        Organizer? organizer = await _organizerService.GetByIdAsync(id, cancellationToken);
 
-        if (organization is null)
+        if (organizer is null)
         {
             return NotFound();
         }
 
-        return Ok(organization);
+        return Ok(organizer);
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Features/OrganizerService.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Features/OrganizerService.cs
@@ -6,7 +6,7 @@ namespace HackYeah2025.Features;
 
 public interface IOrganizerService
 {
-    Task<Organization?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Organizer?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
 }
 
 public class OrganizerService : IOrganizerService
@@ -18,9 +18,10 @@ public class OrganizerService : IOrganizerService
         _dbContext = dbContext;
     }
 
-    public Task<Organization?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    public Task<Organizer?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        return _dbContext.Organizations
+        return _dbContext.Organizers
+            .Include(o => o.Organization)
             .AsNoTracking()
             .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
     }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/HackYeahDbContext.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/HackYeahDbContext.cs
@@ -7,6 +7,7 @@ public sealed class HackYeahDbContext : DbContext
 {
     public DbSet<Event> Events { get; set; }
     public DbSet<Organization> Organizations { get; set; }
+    public DbSet<Organizer> Organizers { get; set; }
 
     public HackYeahDbContext(DbContextOptions<HackYeahDbContext> options) : base(options)
     {
@@ -18,5 +19,6 @@ public sealed class HackYeahDbContext : DbContext
 
         modelBuilder.ApplyConfiguration(new DbEventEntityTypeConfiguration());
         modelBuilder.ApplyConfiguration(new DbOrganizationEntityTypeConfiguration());
+        modelBuilder.ApplyConfiguration(new DbOrganizerEntityTypeConfiguration());
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Organization.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Organization.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -12,6 +13,7 @@ public class Organization
     public string Programs { get; set; }
     public string Mission { get; set; }
     public string Website { get; set; }
+    public ICollection<Organizer> Organizers { get; set; } = new List<Organizer>();
 }
 
 public class DbOrganizationEntityTypeConfiguration : IEntityTypeConfiguration<Organization>
@@ -25,6 +27,9 @@ public class DbOrganizationEntityTypeConfiguration : IEntityTypeConfiguration<Or
         builder.Property(o => o.Programs).IsRequired().HasMaxLength(1024);
         builder.Property(o => o.Mission).IsRequired().HasMaxLength(1024);
         builder.Property(o => o.Website).IsRequired().HasMaxLength(256);
+        builder.HasMany(o => o.Organizers)
+            .WithOne(o => o.Organization)
+            .HasForeignKey(o => o.OrganizationId);
 
         builder.HasData(
             new Organization

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Organizer.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Organizer.cs
@@ -1,0 +1,49 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HackYeah2025.Infrastructure.Models;
+
+public class Organizer
+{
+    public Guid Id { get; set; }
+    public Guid OrganizationId { get; set; }
+    public string FullName { get; set; }
+    public string Role { get; set; }
+    public string Phone { get; set; }
+    public string Email { get; set; }
+    public string Languages { get; set; }
+    public string Specializations { get; set; }
+    public Organization Organization { get; set; }
+}
+
+public class DbOrganizerEntityTypeConfiguration : IEntityTypeConfiguration<Organizer>
+{
+    public void Configure(EntityTypeBuilder<Organizer> builder)
+    {
+        builder.HasKey(o => o.Id);
+        builder.Property(o => o.FullName).IsRequired().HasMaxLength(256);
+        builder.Property(o => o.Role).IsRequired().HasMaxLength(256);
+        builder.Property(o => o.Phone).IsRequired().HasMaxLength(64);
+        builder.Property(o => o.Email).IsRequired().HasMaxLength(256);
+        builder.Property(o => o.Languages).IsRequired().HasMaxLength(256);
+        builder.Property(o => o.Specializations).IsRequired().HasMaxLength(512);
+        builder.HasOne(o => o.Organization)
+            .WithMany(o => o.Organizers)
+            .HasForeignKey(o => o.OrganizationId);
+
+        builder.HasData(
+            new Organizer
+            {
+                Id = Guid.Parse("4b1846cf-3c3a-4939-85f9-884f48216dfb"),
+                OrganizationId = Guid.Parse("5d1f3c76-7a10-4fb4-a4a1-0d5710a98b72"),
+                FullName = "Marta Zawadzka",
+                Role = "Koordynatorka programu",
+                Phone = "+48 501 222 198",
+                Email = "marta.zawadzka@mlodzi-dzialaja.pl",
+                Languages = "polski, angielski",
+                Specializations = "partycypacja młodzieży, partnerstwa lokalne"
+            }
+        );
+    }
+}

--- a/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251004163624_OrganizerInit.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251004163624_OrganizerInit.cs
@@ -43,6 +43,30 @@ namespace HackYeah2025.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "Organizers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrganizationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FullName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Role = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Phone = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Email = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Languages = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Specializations = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Organizers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Organizers_Organizations_OrganizationId",
+                        column: x => x.OrganizationId,
+                        principalTable: "Organizations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "Task",
                 columns: table => new
                 {
@@ -65,15 +89,28 @@ namespace HackYeah2025.Migrations
                 columns: new[] { "Id", "FoundedYear", "Location", "Mission", "Name", "Programs", "Website" },
                 values: new object[] { new Guid("5d1f3c76-7a10-4fb4-a4a1-0d5710a98b72"), 2012, "Centrum Aktywności Społecznej\nul. Solidarności 27\nWarszawa", "Wspieramy młodych liderów w rozwijaniu projektów społecznych, łącząc edukację obywatelską z działaniem w terenie.", "Fundacja Młodzi Działają", "inkubator projektów, mikrogranty sąsiedzkie, akademia wolontariatu", "https://mlodzi-dzialaja.pl" });
 
+            migrationBuilder.InsertData(
+                table: "Organizers",
+                columns: new[] { "Id", "Email", "FullName", "Languages", "OrganizationId", "Phone", "Role", "Specializations" },
+                values: new object[] { new Guid("4b1846cf-3c3a-4939-85f9-884f48216dfb"), "marta.zawadzka@mlodzi-dzialaja.pl", "Marta Zawadzka", "polski, angielski", new Guid("5d1f3c76-7a10-4fb4-a4a1-0d5710a98b72"), "+48 501 222 198", "Koordynatorka programu", "partycypacja młodzieży, partnerstwa lokalne" });
+
             migrationBuilder.CreateIndex(
                 name: "IX_Task_EventId",
                 table: "Task",
                 column: "EventId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Organizers_OrganizationId",
+                table: "Organizers",
+                column: "OrganizationId");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.DropTable(
+                name: "Organizers");
+
             migrationBuilder.DropTable(
                 name: "Organizations");
 

--- a/backend/HackYeah2025.Backend/HackYeah2025/Migrations/HackYeahDbContextModelSnapshot.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Migrations/HackYeahDbContextModelSnapshot.cs
@@ -94,6 +94,65 @@ namespace HackYeah2025.Migrations
                         });
                 });
 
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Organizer", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Email")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("FullName")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("Languages")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<Guid>("OrganizationId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Phone")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
+                    b.Property<string>("Role")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("Specializations")
+                        .IsRequired()
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.ToTable("Organizers");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = new Guid("4b1846cf-3c3a-4939-85f9-884f48216dfb"),
+                            Email = "marta.zawadzka@mlodzi-dzialaja.pl",
+                            FullName = "Marta Zawadzka",
+                            Languages = "polski, angielski",
+                            OrganizationId = new Guid("5d1f3c76-7a10-4fb4-a4a1-0d5710a98b72"),
+                            Phone = "+48 501 222 198",
+                            Role = "Koordynatorka programu",
+                            Specializations = "partycypacja młodzieży, partnerstwa lokalne"
+                        });
+                });
+
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Task", b =>
                 {
                     b.Property<Guid>("Id")
@@ -119,9 +178,25 @@ namespace HackYeah2025.Migrations
                         .IsRequired();
                 });
 
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Organizer", b =>
+                {
+                    b.HasOne("HackYeah2025.Infrastructure.Models.Organization", "Organization")
+                        .WithMany("Organizers")
+                        .HasForeignKey("OrganizationId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Organization");
+                });
+
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Event", b =>
                 {
                     b.Navigation("Tasks");
+                });
+
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Organization", b =>
+                {
+                    b.Navigation("Organizers");
                 });
 #pragma warning restore 612, 618
         }


### PR DESCRIPTION
## Summary
- add an Organizer entity with configuration, relationship to organizations, and seed data for Marta Zawadzka
- extend the data context, service, and controller to expose organizer details through the API

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e14fecf1d0832081bbd95085f3cdfc