### PR TITLE
Add volunteer entity, service, and retrieval API

### DIFF
--- a/backend/HackYeah2025.Backend/HackYeah2025/Features/VolunteerController.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Features/VolunteerController.cs
@@ -1,15 +1,29 @@
-﻿using Microsoft.AspNetCore.Http;
+using HackYeah2025.Infrastructure.Models;
 using Microsoft.AspNetCore.Mvc;
 
-namespace HackYeah2025.Features
+namespace HackYeah2025.Features;
+
+[Route("api/[controller]")]
+[ApiController]
+public class VolunteerController : ControllerBase
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class VolunteerController : ControllerBase
+    private readonly IVolunteerService _volunteerService;
+
+    public VolunteerController(IVolunteerService volunteerService)
     {
-        public VolunteerController()
+        _volunteerService = volunteerService;
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<Volunteer>> Get(Guid id, CancellationToken cancellationToken)
+    {
+        Volunteer? volunteer = await _volunteerService.GetByIdAsync(id, cancellationToken);
+
+        if (volunteer is null)
         {
-            
+            return NotFound();
         }
+
+        return Ok(volunteer);
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Features/VolunteerService.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Features/VolunteerService.cs
@@ -1,0 +1,30 @@
+using HackYeah2025.Infrastructure;
+using HackYeah2025.Infrastructure.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace HackYeah2025.Features;
+
+public interface IVolunteerService
+{
+    Task<Volunteer?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+}
+
+public class VolunteerService : IVolunteerService
+{
+    private readonly HackYeahDbContext _dbContext;
+
+    public VolunteerService(HackYeahDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<Volunteer?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.Volunteers
+            .Include(v => v.VolunteerTags)
+                .ThenInclude(vt => vt.Tag)
+            .Include(v => v.Distinctions)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(v => v.Id == id, cancellationToken);
+    }
+}

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/HackYeahDbContext.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/HackYeahDbContext.cs
@@ -8,6 +8,10 @@ public sealed class HackYeahDbContext : DbContext
     public DbSet<Event> Events { get; set; }
     public DbSet<Organization> Organizations { get; set; }
     public DbSet<Organizer> Organizers { get; set; }
+    public DbSet<Volunteer> Volunteers { get; set; }
+    public DbSet<Tag> Tags { get; set; }
+    public DbSet<VolunteerTag> VolunteerTags { get; set; }
+    public DbSet<VolunteerDistinction> VolunteerDistinctions { get; set; }
 
     public HackYeahDbContext(DbContextOptions<HackYeahDbContext> options) : base(options)
     {
@@ -20,5 +24,9 @@ public sealed class HackYeahDbContext : DbContext
         modelBuilder.ApplyConfiguration(new DbEventEntityTypeConfiguration());
         modelBuilder.ApplyConfiguration(new DbOrganizationEntityTypeConfiguration());
         modelBuilder.ApplyConfiguration(new DbOrganizerEntityTypeConfiguration());
+        modelBuilder.ApplyConfiguration(new DbVolunteerEntityTypeConfiguration());
+        modelBuilder.ApplyConfiguration(new DbTagEntityTypeConfiguration());
+        modelBuilder.ApplyConfiguration(new DbVolunteerTagEntityTypeConfiguration());
+        modelBuilder.ApplyConfiguration(new DbVolunteerDistinctionEntityTypeConfiguration());
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Tag.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Tag.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HackYeah2025.Infrastructure.Models;
+
+public class Tag
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    [JsonIgnore]
+    public ICollection<VolunteerTag> VolunteerTags { get; set; } = new List<VolunteerTag>();
+}
+
+public class VolunteerTag
+{
+    public Guid VolunteerId { get; set; }
+    [JsonIgnore]
+    public Volunteer Volunteer { get; set; } = null!;
+    public Guid TagId { get; set; }
+    public Tag Tag { get; set; } = null!;
+}
+
+public class DbTagEntityTypeConfiguration : IEntityTypeConfiguration<Tag>
+{
+    public void Configure(EntityTypeBuilder<Tag> builder)
+    {
+        builder.ToTable("Tags");
+        builder.HasKey(t => t.Id);
+        builder.Property(t => t.Name).IsRequired().HasMaxLength(128);
+
+        builder.HasMany(t => t.VolunteerTags)
+            .WithOne(vt => vt.Tag)
+            .HasForeignKey(vt => vt.TagId);
+
+        builder.HasData(
+            new Tag { Id = Guid.Parse("9a3e0ca5-579f-49ba-a479-76a519e5c08a"), Name = "Integracja młodzieży" },
+            new Tag { Id = Guid.Parse("0b93ef04-03ea-4bb8-8aa4-2a0d9c51bfb3"), Name = "Wsparcie seniorów" },
+            new Tag { Id = Guid.Parse("1a6d420a-4851-45ce-b756-609d0c48e1c6"), Name = "Wydarzenia kulturalne" },
+            new Tag { Id = Guid.Parse("1d8cb68b-20da-4c4c-93f0-326f0f7a086b"), Name = "Edukacja obywatelska" }
+        );
+    }
+}
+
+public class DbVolunteerTagEntityTypeConfiguration : IEntityTypeConfiguration<VolunteerTag>
+{
+    public void Configure(EntityTypeBuilder<VolunteerTag> builder)
+    {
+        builder.ToTable("VolunteerTags");
+        builder.HasKey(vt => new { vt.VolunteerId, vt.TagId });
+
+        builder.HasOne(vt => vt.Volunteer)
+            .WithMany(v => v.VolunteerTags)
+            .HasForeignKey(vt => vt.VolunteerId);
+
+        builder.HasOne(vt => vt.Tag)
+            .WithMany(t => t.VolunteerTags)
+            .HasForeignKey(vt => vt.TagId);
+
+        builder.HasData(
+            new VolunteerTag { VolunteerId = Guid.Parse("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"), TagId = Guid.Parse("9a3e0ca5-579f-49ba-a479-76a519e5c08a") },
+            new VolunteerTag { VolunteerId = Guid.Parse("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"), TagId = Guid.Parse("0b93ef04-03ea-4bb8-8aa4-2a0d9c51bfb3") },
+            new VolunteerTag { VolunteerId = Guid.Parse("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"), TagId = Guid.Parse("1a6d420a-4851-45ce-b756-609d0c48e1c6") },
+            new VolunteerTag { VolunteerId = Guid.Parse("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"), TagId = Guid.Parse("1d8cb68b-20da-4c4c-93f0-326f0f7a086b") }
+        );
+    }
+}

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Volunteer.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Volunteer.cs
@@ -1,6 +1,89 @@
-﻿namespace HackYeah2025.Infrastructure.Models
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HackYeah2025.Infrastructure.Models;
+
+public class Volunteer
 {
-    public class Volunteer
+    public Guid Id { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public Dictionary<string, string> Availability { get; set; } = new();
+    public string PreferredRoles { get; set; } = string.Empty;
+    public Dictionary<string, string> Languages { get; set; } = new();
+    public string Transport { get; set; } = string.Empty;
+    public Dictionary<string, string> Skills { get; set; } = new();
+    public string Email { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    [JsonIgnore]
+    public ICollection<VolunteerTag> VolunteerTags { get; set; } = new List<VolunteerTag>();
+    public ICollection<VolunteerDistinction> Distinctions { get; set; } = new List<VolunteerDistinction>();
+    [NotMapped]
+    public IEnumerable<Tag> Tags => VolunteerTags.Select(vt => vt.Tag);
+}
+
+public class DbVolunteerEntityTypeConfiguration : IEntityTypeConfiguration<Volunteer>
+{
+    public void Configure(EntityTypeBuilder<Volunteer> builder)
     {
+        builder.ToTable("Volunteers");
+        builder.HasKey(v => v.Id);
+        builder.Property(v => v.FirstName).IsRequired().HasMaxLength(128);
+        builder.Property(v => v.LastName).IsRequired().HasMaxLength(128);
+        builder.Property(v => v.Description).IsRequired().HasMaxLength(1024);
+        builder.Property(v => v.Availability).IsRequired().HasColumnType("jsonb");
+        builder.Property(v => v.PreferredRoles).IsRequired().HasMaxLength(512);
+        builder.Property(v => v.Languages).IsRequired().HasColumnType("jsonb");
+        builder.Property(v => v.Transport).IsRequired().HasMaxLength(256);
+        builder.Property(v => v.Skills).IsRequired().HasColumnType("jsonb");
+        builder.Property(v => v.Email).IsRequired().HasMaxLength(256);
+        builder.Property(v => v.Phone).IsRequired().HasMaxLength(64);
+
+        builder.HasMany(v => v.VolunteerTags)
+            .WithOne(vt => vt.Volunteer)
+            .HasForeignKey(vt => vt.VolunteerId);
+
+        builder.HasMany(v => v.Distinctions)
+            .WithOne(d => d.Volunteer)
+            .HasForeignKey(d => d.VolunteerId);
+
+        Guid volunteerId = Guid.Parse("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8");
+
+        builder.HasData(
+            new Volunteer
+            {
+                Id = volunteerId,
+                FirstName = "Julia",
+                LastName = "Nowak",
+                Description = "Doświadczona wolontariuszka wspierająca projekty międzypokoleniowe oraz wydarzenia edukacyjne.",
+                Availability = new Dictionary<string, string>
+                {
+                    ["tuesday_thursday"] = "Wtorki i czwartki 16:00 – 20:00",
+                    ["weekends"] = "Weekendy według ustaleń"
+                },
+                PreferredRoles = "Koordynacja wolontariuszy, prowadzenie warsztatów, moderacja spotkań",
+                Languages = new Dictionary<string, string>
+                {
+                    ["Polski"] = "C2",
+                    ["Angielski"] = "C1",
+                    ["Ukraiński"] = "B1"
+                },
+                Transport = "Rower, komunikacja miejska, możliwość dojazdu do 20 km",
+                Skills = new Dictionary<string, string>
+                {
+                    ["Komunikacja i moderacja"] = "Zaawansowany",
+                    ["Animacja czasu wolnego"] = "Średniozaawansowany",
+                    ["Pierwsza pomoc"] = "Podstawowy",
+                    ["Planowanie wydarzeń"] = "Zaawansowany"
+                },
+                Email = "julia.nowak@mlodzidzialaja.pl",
+                Phone = "+48 511 222 333"
+            }
+        );
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/VolunteerDistinction.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/VolunteerDistinction.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using System.Text.Json.Serialization;
+
+namespace HackYeah2025.Infrastructure.Models;
+
+public class VolunteerDistinction
+{
+    public Guid Id { get; set; }
+    public Guid VolunteerId { get; set; }
+    [JsonIgnore]
+    public Volunteer Volunteer { get; set; } = null!;
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+}
+
+public class DbVolunteerDistinctionEntityTypeConfiguration : IEntityTypeConfiguration<VolunteerDistinction>
+{
+    public void Configure(EntityTypeBuilder<VolunteerDistinction> builder)
+    {
+        builder.ToTable("VolunteerDistinctions");
+        builder.HasKey(d => d.Id);
+        builder.Property(d => d.Title).IsRequired().HasMaxLength(256);
+        builder.Property(d => d.Description).IsRequired().HasMaxLength(1024);
+
+        builder.HasOne(d => d.Volunteer)
+            .WithMany(v => v.Distinctions)
+            .HasForeignKey(d => d.VolunteerId);
+
+        builder.HasData(
+            new VolunteerDistinction
+            {
+                Id = Guid.Parse("8d5fdf09-04ac-4b76-bbef-f5fb3787e6bf"),
+                VolunteerId = Guid.Parse("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"),
+                Title = "Nagroda \"Wolontariusz roku\"",
+                Description = "Wyróżnienie za 120 godzin pracy z młodzieżą i seniorami w 2024 roku."
+            },
+            new VolunteerDistinction
+            {
+                Id = Guid.Parse("9e0c6883-9461-4d6f-b6f2-f2de4f6dd0a4"),
+                VolunteerId = Guid.Parse("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"),
+                Title = "Certyfikat z pierwszej pomocy",
+                Description = "Ukończony kurs Polskiego Czerwonego Krzyża, obejmujący scenariusze miejskie."
+            }
+        );
+    }
+}

--- a/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251004180000_VolunteerInit.Designer.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251004180000_VolunteerInit.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using HackYeah2025.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HackYeah2025.Migrations
 {
     [DbContext(typeof(HackYeahDbContext))]
-    partial class HackYeahDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251004180000_VolunteerInit")]
+    partial class VolunteerInit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251004180000_VolunteerInit.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251004180000_VolunteerInit.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HackYeah2025.Migrations
+{
+    /// <inheritdoc />
+    public partial class VolunteerInit : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Tags",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Tags", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Volunteers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    FirstName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    LastName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    Availability = table.Column<Dictionary<string, string>>(type: "jsonb", nullable: false),
+                    PreferredRoles = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    Languages = table.Column<Dictionary<string, string>>(type: "jsonb", nullable: false),
+                    Transport = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Skills = table.Column<Dictionary<string, string>>(type: "jsonb", nullable: false),
+                    Email = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Phone = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Volunteers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VolunteerDistinctions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    VolunteerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VolunteerDistinctions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VolunteerDistinctions_Volunteers_VolunteerId",
+                        column: x => x.VolunteerId,
+                        principalTable: "Volunteers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VolunteerTags",
+                columns: table => new
+                {
+                    VolunteerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TagId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VolunteerTags", x => new { x.VolunteerId, x.TagId });
+                    table.ForeignKey(
+                        name: "FK_VolunteerTags_Tags_TagId",
+                        column: x => x.TagId,
+                        principalTable: "Tags",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_VolunteerTags_Volunteers_VolunteerId",
+                        column: x => x.VolunteerId,
+                        principalTable: "Volunteers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.InsertData(
+                table: "Tags",
+                columns: new[] { "Id", "Name" },
+                values: new object[,]
+                {
+                    { new Guid("9a3e0ca5-579f-49ba-a479-76a519e5c08a"), "Integracja młodzieży" },
+                    { new Guid("0b93ef04-03ea-4bb8-8aa4-2a0d9c51bfb3"), "Wsparcie seniorów" },
+                    { new Guid("1a6d420a-4851-45ce-b756-609d0c48e1c6"), "Wydarzenia kulturalne" },
+                    { new Guid("1d8cb68b-20da-4c4c-93f0-326f0f7a086b"), "Edukacja obywatelska" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Volunteers",
+                columns: new[] { "Id", "Availability", "Description", "Email", "FirstName", "Languages", "LastName", "Phone", "PreferredRoles", "Skills", "Transport" },
+                values: new object[]
+                {
+                    new Guid("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"),
+                    new Dictionary<string, string>
+                    {
+                        { "tuesday_thursday", "Wtorki i czwartki 16:00 – 20:00" },
+                        { "weekends", "Weekendy według ustaleń" }
+                    },
+                    "Doświadczona wolontariuszka wspierająca projekty międzypokoleniowe oraz wydarzenia edukacyjne.",
+                    "julia.nowak@mlodzidzialaja.pl",
+                    "Julia",
+                    new Dictionary<string, string>
+                    {
+                        { "Polski", "C2" },
+                        { "Angielski", "C1" },
+                        { "Ukraiński", "B1" }
+                    },
+                    "Nowak",
+                    "+48 511 222 333",
+                    "Koordynacja wolontariuszy, prowadzenie warsztatów, moderacja spotkań",
+                    new Dictionary<string, string>
+                    {
+                        { "Komunikacja i moderacja", "Zaawansowany" },
+                        { "Animacja czasu wolnego", "Średniozaawansowany" },
+                        { "Pierwsza pomoc", "Podstawowy" },
+                        { "Planowanie wydarzeń", "Zaawansowany" }
+                    },
+                    "Rower, komunikacja miejska, możliwość dojazdu do 20 km"
+                });
+
+            migrationBuilder.InsertData(
+                table: "VolunteerDistinctions",
+                columns: new[] { "Id", "Description", "Title", "VolunteerId" },
+                values: new object[,]
+                {
+                    { new Guid("8d5fdf09-04ac-4b76-bbef-f5fb3787e6bf"), "Wyróżnienie za 120 godzin pracy z młodzieżą i seniorami w 2024 roku.", "Nagroda \"Wolontariusz roku\"", new Guid("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8") },
+                    { new Guid("9e0c6883-9461-4d6f-b6f2-f2de4f6dd0a4"), "Ukończony kurs Polskiego Czerwonego Krzyża, obejmujący scenariusze miejskie.", "Certyfikat z pierwszej pomocy", new Guid("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8") }
+                });
+
+            migrationBuilder.InsertData(
+                table: "VolunteerTags",
+                columns: new[] { "VolunteerId", "TagId" },
+                values: new object[,]
+                {
+                    { new Guid("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"), new Guid("9a3e0ca5-579f-49ba-a479-76a519e5c08a") },
+                    { new Guid("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"), new Guid("0b93ef04-03ea-4bb8-8aa4-2a0d9c51bfb3") },
+                    { new Guid("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"), new Guid("1a6d420a-4851-45ce-b756-609d0c48e1c6") },
+                    { new Guid("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"), new Guid("1d8cb68b-20da-4c4c-93f0-326f0f7a086b") }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VolunteerDistinctions_VolunteerId",
+                table: "VolunteerDistinctions",
+                column: "VolunteerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VolunteerTags_TagId",
+                table: "VolunteerTags",
+                column: "TagId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "VolunteerDistinctions");
+
+            migrationBuilder.DropTable(
+                name: "VolunteerTags");
+
+            migrationBuilder.DropTable(
+                name: "Tags");
+
+            migrationBuilder.DropTable(
+                name: "Volunteers");
+        }
+    }
+}

--- a/backend/HackYeah2025.Backend/HackYeah2025/Program.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddDbContext<HackYeahDbContext>(o =>
     o.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection"))
 );
 builder.Services.AddScoped<IOrganizerService, OrganizerService>();
+builder.Services.AddScoped<IVolunteerService, VolunteerService>();
 
 WebApplication app = builder.Build();
 


### PR DESCRIPTION
## Summary
- add a volunteer domain model with tags, distinctions, json-based skill and availability data, and seed content
- create a volunteer service and controller endpoint to fetch a volunteer with related data
- extend the database context and migrations to materialize the new volunteer schema and seed records

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e152cc42288320b6634584d06be0ee