### PR TITLE
Handle JSON cycles in organizer responses

### DIFF
--- a/backend/HackYeah2025.Backend/HackYeah2025/Program.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Program.cs
@@ -1,10 +1,14 @@
 using HackYeah2025.Features;
 using HackYeah2025.Infrastructure;
 using Microsoft.EntityFrameworkCore;
+using System.Text.Json.Serialization;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
+builder.Services.AddControllers().AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+});
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 


### PR DESCRIPTION
## Summary
- configure controller serialization to ignore reference cycles when returning EF entities
- add System.Text.Json dependency to program setup to resolve organizer and organization loops

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1553ef75c8320951fd10714d6d464