### PR TITLE
Fix volunteer seed data to stop dynamic model changes

### DIFF
--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Volunteer.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Volunteer.cs
@@ -29,6 +29,44 @@ public class Volunteer
 
 public class DbVolunteerEntityTypeConfiguration : IEntityTypeConfiguration<Volunteer>
 {
+    private static readonly Guid SeedVolunteerId = Guid.Parse("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8");
+
+    private static readonly Dictionary<string, string> SeedAvailability = new()
+    {
+        ["tuesday_thursday"] = "Wtorki i czwartki 16:00 – 20:00",
+        ["weekends"] = "Weekendy według ustaleń"
+    };
+
+    private static readonly Dictionary<string, string> SeedLanguages = new()
+    {
+        ["Polski"] = "C2",
+        ["Angielski"] = "C1",
+        ["Ukraiński"] = "B1"
+    };
+
+    private static readonly Dictionary<string, string> SeedSkills = new()
+    {
+        ["Komunikacja i moderacja"] = "Zaawansowany",
+        ["Animacja czasu wolnego"] = "Średniozaawansowany",
+        ["Pierwsza pomoc"] = "Podstawowy",
+        ["Planowanie wydarzeń"] = "Zaawansowany"
+    };
+
+    private static readonly Volunteer SeedVolunteer = new()
+    {
+        Id = SeedVolunteerId,
+        FirstName = "Julia",
+        LastName = "Nowak",
+        Description = "Doświadczona wolontariuszka wspierająca projekty międzypokoleniowe oraz wydarzenia edukacyjne.",
+        Availability = SeedAvailability,
+        PreferredRoles = "Koordynacja wolontariuszy, prowadzenie warsztatów, moderacja spotkań",
+        Languages = SeedLanguages,
+        Transport = "Rower, komunikacja miejska, możliwość dojazdu do 20 km",
+        Skills = SeedSkills,
+        Email = "julia.nowak@mlodzidzialaja.pl",
+        Phone = "+48 511 222 333"
+    };
+
     public void Configure(EntityTypeBuilder<Volunteer> builder)
     {
         builder.ToTable("Volunteers");
@@ -52,38 +90,6 @@ public class DbVolunteerEntityTypeConfiguration : IEntityTypeConfiguration<Volun
             .WithOne(d => d.Volunteer)
             .HasForeignKey(d => d.VolunteerId);
 
-        Guid volunteerId = Guid.Parse("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8");
-
-        builder.HasData(
-            new Volunteer
-            {
-                Id = volunteerId,
-                FirstName = "Julia",
-                LastName = "Nowak",
-                Description = "Doświadczona wolontariuszka wspierająca projekty międzypokoleniowe oraz wydarzenia edukacyjne.",
-                Availability = new Dictionary<string, string>
-                {
-                    ["tuesday_thursday"] = "Wtorki i czwartki 16:00 – 20:00",
-                    ["weekends"] = "Weekendy według ustaleń"
-                },
-                PreferredRoles = "Koordynacja wolontariuszy, prowadzenie warsztatów, moderacja spotkań",
-                Languages = new Dictionary<string, string>
-                {
-                    ["Polski"] = "C2",
-                    ["Angielski"] = "C1",
-                    ["Ukraiński"] = "B1"
-                },
-                Transport = "Rower, komunikacja miejska, możliwość dojazdu do 20 km",
-                Skills = new Dictionary<string, string>
-                {
-                    ["Komunikacja i moderacja"] = "Zaawansowany",
-                    ["Animacja czasu wolnego"] = "Średniozaawansowany",
-                    ["Pierwsza pomoc"] = "Podstawowy",
-                    ["Planowanie wydarzeń"] = "Zaawansowany"
-                },
-                Email = "julia.nowak@mlodzidzialaja.pl",
-                Phone = "+48 511 222 333"
-            }
-        );
+        builder.HasData(SeedVolunteer);
     }
 }


### PR DESCRIPTION
## Summary
- reuse static seed instances for the volunteer entity to avoid dynamic dictionary allocations that changed the EF model on each build

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e15664878483209efd40e28939a6cc