### PR TITLE
Add event domain details and retrieval endpoint

### DIFF
--- a/backend/HackYeah2025.Backend/HackYeah2025/Features/EventController.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Features/EventController.cs
@@ -1,34 +1,28 @@
-﻿using HackYeah2025.Infrastructure.Models;
-using Microsoft.AspNetCore.Http;
+using HackYeah2025.Infrastructure.Models;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
-namespace HackYeah2025.Features
+namespace HackYeah2025.Features;
+
+[ApiController]
+[Route("api/[controller]")]
+public class EventController : ControllerBase
 {
-    [ApiController]
-    [Route("api/[controller]")]
-    public class EventController : ControllerBase
+    private readonly IEventService _eventService;
+
+    public EventController(IEventService eventService)
     {
-        public EventController()
+        _eventService = eventService;
+    }
+
+    [HttpGet("{eventId:guid}")]
+    public async Task<ActionResult<Event>> Get(Guid eventId, CancellationToken cancellationToken)
+    {
+        Event? result = await _eventService.GetByIdAsync(eventId, cancellationToken);
+        if (result is null)
         {
-            
+            return NotFound();
         }
 
-        [HttpPost("search")]
-        public async Task<ActionResult<List<Event>>> Search()
-        {
-            return Ok(new());
-        }
-
-
-
-        [HttpGet("{eventId}")]
-        public async Task<ActionResult<Event>> Get(Guid id)
-        {
-
-            return Ok(new());
-
-        }
-
+        return Ok(result);
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Features/EventService.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Features/EventService.cs
@@ -1,0 +1,29 @@
+using HackYeah2025.Infrastructure;
+using HackYeah2025.Infrastructure.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace HackYeah2025.Features;
+
+public interface IEventService
+{
+    Task<Event?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+}
+
+public class EventService : IEventService
+{
+    private readonly HackYeahDbContext _dbContext;
+
+    public EventService(HackYeahDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<Event?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.Events
+            .Include(e => e.EventEventTopics)
+                .ThenInclude(eet => eet.EventTopic)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == id, cancellationToken);
+    }
+}

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/HackYeahDbContext.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/HackYeahDbContext.cs
@@ -12,6 +12,8 @@ public sealed class HackYeahDbContext : DbContext
     public DbSet<Tag> Tags { get; set; }
     public DbSet<VolunteerTag> VolunteerTags { get; set; }
     public DbSet<VolunteerDistinction> VolunteerDistinctions { get; set; }
+    public DbSet<EventTopic> EventTopics { get; set; }
+    public DbSet<EventEventTopic> EventEventTopics { get; set; }
 
     public HackYeahDbContext(DbContextOptions<HackYeahDbContext> options) : base(options)
     {
@@ -28,5 +30,7 @@ public sealed class HackYeahDbContext : DbContext
         modelBuilder.ApplyConfiguration(new DbTagEntityTypeConfiguration());
         modelBuilder.ApplyConfiguration(new DbVolunteerTagEntityTypeConfiguration());
         modelBuilder.ApplyConfiguration(new DbVolunteerDistinctionEntityTypeConfiguration());
+        modelBuilder.ApplyConfiguration(new DbEventTopicEntityTypeConfiguration());
+        modelBuilder.ApplyConfiguration(new DbEventEventTopicEntityTypeConfiguration());
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Event.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Event.cs
@@ -1,26 +1,61 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace HackYeah2025.Infrastructure.Models
+namespace HackYeah2025.Infrastructure.Models;
+
+public class Event
 {
-    public class Event
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string ShortDescription { get; set; } = string.Empty;
+    public string LongDescription { get; set; } = string.Empty;
+    public DateTimeOffset DateFrom { get; set; }
+    public DateTimeOffset DateTo { get; set; }
+    public string Place { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public decimal Latitude { get; set; }
+    public decimal Longitude { get; set; }
+
+    public List<Task> Tasks { get; set; } = new();
+    public ICollection<EventEventTopic> EventEventTopics { get; set; } = new List<EventEventTopic>();
+}
+
+public class DbEventEntityTypeConfiguration : IEntityTypeConfiguration<Event>
+{
+    public void Configure(EntityTypeBuilder<Event> builder)
     {
-        public Guid Id { get; set; }
-        public string Title { get; set; }
-        public DateTimeOffset DateFrom { get; set; }
-        public DateTimeOffset DateTo { get; set; }
+        builder.HasKey(u => u.Id);
+        builder.Property(e => e.Name).IsRequired().HasMaxLength(256);
+        builder.Property(e => e.ShortDescription).IsRequired().HasMaxLength(1024);
+        builder.Property(e => e.LongDescription).IsRequired();
+        builder.Property(e => e.Place).IsRequired().HasMaxLength(256);
+        builder.Property(e => e.City).IsRequired().HasMaxLength(128);
+        builder.Property(e => e.Address).IsRequired().HasMaxLength(256);
+        builder.Property(e => e.Latitude).HasColumnType("decimal(9,6)");
+        builder.Property(e => e.Longitude).HasColumnType("decimal(9,6)");
 
-        public List<Task> Tasks { get; set; }
+        builder.HasMany(e => e.EventEventTopics)
+            .WithOne(eet => eet.Event)
+            .HasForeignKey(eet => eet.EventId);
 
+        Guid eventId = Guid.Parse("2b4ae59e-7adf-4a95-a410-9ec118984d47");
 
-
-    }
-
-    public class DbEventEntityTypeConfiguration : IEntityTypeConfiguration<Event>
-    {
-        public void Configure(EntityTypeBuilder<Event> builder)
-        {
-            builder.HasKey(u => u.Id);
-        }
+        builder.HasData(
+            new Event
+            {
+                Id = eventId,
+                Name = "Civic Lab 2025",
+                ShortDescription = "Trzydniowe laboratorium projektowe, w trakcie którego młodzież tworzy rozwiązania dla wyzwań lokalnych.",
+                LongDescription = "Civic Lab 2025 to intensywny proces projektowy, w którym zespoły młodzieżowe pracują z mentorami nad realnymi wyzwaniami miast. Uczestnicy przejdą przez etap diagnozy problemu, prototypowania rozwiązań oraz przygotowania prezentacji przed jury złożonym z przedstawicieli samorządów i organizacji społecznych.",
+                DateFrom = new DateTimeOffset(new DateTime(2025, 4, 10), TimeSpan.Zero),
+                DateTo = new DateTimeOffset(new DateTime(2025, 4, 12), TimeSpan.Zero),
+                Place = "Centrum Innowacji Młodych",
+                City = "Warszawa",
+                Address = "ul. Przemian 4",
+                Latitude = 50.067930m,
+                Longitude = 19.983189m
+            }
+        );
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/EventTopic.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/EventTopic.cs
@@ -1,0 +1,76 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HackYeah2025.Infrastructure.Models;
+
+public class EventTopic
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public ICollection<EventEventTopic> EventEventTopics { get; set; } = new List<EventEventTopic>();
+}
+
+public class EventEventTopic
+{
+    public Guid EventId { get; set; }
+    public Event Event { get; set; } = null!;
+    public Guid EventTopicId { get; set; }
+    public EventTopic EventTopic { get; set; } = null!;
+}
+
+public class DbEventTopicEntityTypeConfiguration : IEntityTypeConfiguration<EventTopic>
+{
+    public void Configure(EntityTypeBuilder<EventTopic> builder)
+    {
+        builder.ToTable("EventTopics");
+        builder.HasKey(et => et.Id);
+        builder.Property(et => et.Name).IsRequired().HasMaxLength(128);
+
+        builder.HasMany(et => et.EventEventTopics)
+            .WithOne(eet => eet.EventTopic)
+            .HasForeignKey(eet => eet.EventTopicId);
+
+        builder.HasData(
+            new EventTopic
+            {
+                Id = Guid.Parse("3acb29ab-38b3-4ce3-89ad-2fd25ed4a51c"),
+                Name = "innowacje społeczne"
+            },
+            new EventTopic
+            {
+                Id = Guid.Parse("d46920c0-0b77-4a0e-8c1f-9af70906cb60"),
+                Name = "edukacja obywatelska"
+            }
+        );
+    }
+}
+
+public class DbEventEventTopicEntityTypeConfiguration : IEntityTypeConfiguration<EventEventTopic>
+{
+    public void Configure(EntityTypeBuilder<EventEventTopic> builder)
+    {
+        builder.ToTable("EventEventTopics");
+        builder.HasKey(eet => new { eet.EventId, eet.EventTopicId });
+
+        builder.HasOne(eet => eet.Event)
+            .WithMany(e => e.EventEventTopics)
+            .HasForeignKey(eet => eet.EventId);
+
+        builder.HasOne(eet => eet.EventTopic)
+            .WithMany(et => et.EventEventTopics)
+            .HasForeignKey(eet => eet.EventTopicId);
+
+        builder.HasData(
+            new EventEventTopic
+            {
+                EventId = Guid.Parse("2b4ae59e-7adf-4a95-a410-9ec118984d47"),
+                EventTopicId = Guid.Parse("3acb29ab-38b3-4ce3-89ad-2fd25ed4a51c")
+            },
+            new EventEventTopic
+            {
+                EventId = Guid.Parse("2b4ae59e-7adf-4a95-a410-9ec118984d47"),
+                EventTopicId = Guid.Parse("d46920c0-0b77-4a0e-8c1f-9af70906cb60")
+            }
+        );
+    }
+}

--- a/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251004171515_Init.Designer.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251004171515_Init.Designer.cs
@@ -32,19 +32,66 @@ namespace HackYeah2025.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
+                    b.Property<string>("Address")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("City")
+                        .IsRequired()
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
+
                     b.Property<DateTimeOffset>("DateFrom")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset>("DateTo")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("Title")
+                    b.Property<decimal>("Latitude")
+                        .HasColumnType("numeric(9,6)");
+
+                    b.Property<string>("LongDescription")
                         .IsRequired()
                         .HasColumnType("text");
+
+                    b.Property<decimal>("Longitude")
+                        .HasColumnType("numeric(9,6)");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("Place")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("ShortDescription")
+                        .IsRequired()
+                        .HasMaxLength(1024)
+                        .HasColumnType("character varying(1024)");
 
                     b.HasKey("Id");
 
                     b.ToTable("Events");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = new Guid("2b4ae59e-7adf-4a95-a410-9ec118984d47"),
+                            Address = "ul. Przemian 4",
+                            City = "Warszawa",
+                            DateFrom = new DateTimeOffset(new DateTime(2025, 4, 10, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                            DateTo = new DateTimeOffset(new DateTime(2025, 4, 12, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                            Latitude = 50.067930m,
+                            LongDescription = "Civic Lab 2025 to intensywny proces projektowy, w którym zespoły młodzieżowe pracują z mentorami nad realnymi wyzwaniami miast. Uczestnicy przejdą przez etap diagnozy problemu, prototypowania rozwiązań oraz przygotowania prezentacji przed jury złożonym z przedstawicieli samorządów i organizacji społecznych.",
+                            Longitude = 19.983189m,
+                            Name = "Civic Lab 2025",
+                            Place = "Centrum Innowacji Młodych",
+                            ShortDescription = "Trzydniowe laboratorium projektowe, w trakcie którego młodzież tworzy rozwiązania dla wyzwań lokalnych."
+                        });
                 });
 
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Organization", b =>
@@ -192,6 +239,61 @@ namespace HackYeah2025.Migrations
                         {
                             Id = new Guid("1d8cb68b-20da-4c4c-93f0-326f0f7a086b"),
                             Name = "Edukacja obywatelska"
+                        });
+                });
+
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.EventTopic", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("EventTopics");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = new Guid("3acb29ab-38b3-4ce3-89ad-2fd25ed4a51c"),
+                            Name = "innowacje społeczne"
+                        },
+                        new
+                        {
+                            Id = new Guid("d46920c0-0b77-4a0e-8c1f-9af70906cb60"),
+                            Name = "edukacja obywatelska"
+                        });
+                });
+
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.EventEventTopic", b =>
+                {
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("EventTopicId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("EventId", "EventTopicId");
+
+                    b.HasIndex("EventTopicId");
+
+                    b.ToTable("EventEventTopics");
+
+                    b.HasData(
+                        new
+                        {
+                            EventId = new Guid("2b4ae59e-7adf-4a95-a410-9ec118984d47"),
+                            EventTopicId = new Guid("3acb29ab-38b3-4ce3-89ad-2fd25ed4a51c")
+                        },
+                        new
+                        {
+                            EventId = new Guid("2b4ae59e-7adf-4a95-a410-9ec118984d47"),
+                            EventTopicId = new Guid("d46920c0-0b77-4a0e-8c1f-9af70906cb60")
                         });
                 });
 
@@ -384,6 +486,25 @@ namespace HackYeah2025.Migrations
                         .IsRequired();
                 });
 
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.EventEventTopic", b =>
+                {
+                    b.HasOne("HackYeah2025.Infrastructure.Models.Event", "Event")
+                        .WithMany("EventEventTopics")
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("HackYeah2025.Infrastructure.Models.EventTopic", "EventTopic")
+                        .WithMany("EventEventTopics")
+                        .HasForeignKey("EventTopicId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Event");
+
+                    b.Navigation("EventTopic");
+                });
+
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.VolunteerDistinction", b =>
                 {
                     b.HasOne("HackYeah2025.Infrastructure.Models.Volunteer", "Volunteer")
@@ -416,7 +537,14 @@ namespace HackYeah2025.Migrations
 
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Event", b =>
                 {
+                    b.Navigation("EventEventTopics");
+
                     b.Navigation("Tasks");
+                });
+
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.EventTopic", b =>
+                {
+                    b.Navigation("EventEventTopics");
                 });
 
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Organization", b =>

--- a/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251004171515_Init.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251004171515_Init.cs
@@ -19,9 +19,16 @@ namespace HackYeah2025.Migrations
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    Title = table.Column<string>(type: "text", nullable: false),
+                    Name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    ShortDescription = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    LongDescription = table.Column<string>(type: "text", nullable: false),
                     DateFrom = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    DateTo = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                    DateTo = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Place = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    City = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Address = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Latitude = table.Column<decimal>(type: "numeric(9,6)", nullable: false),
+                    Longitude = table.Column<decimal>(type: "numeric(9,6)", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -55,6 +62,18 @@ namespace HackYeah2025.Migrations
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_Tags", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "EventTopics",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EventTopics", x => x.Id);
                 });
 
             migrationBuilder.CreateTable(
@@ -92,6 +111,30 @@ namespace HackYeah2025.Migrations
                         name: "FK_Task_Events_EventId",
                         column: x => x.EventId,
                         principalTable: "Events",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "EventEventTopics",
+                columns: table => new
+                {
+                    EventId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EventTopicId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EventEventTopics", x => new { x.EventId, x.EventTopicId });
+                    table.ForeignKey(
+                        name: "FK_EventEventTopics_Events_EventId",
+                        column: x => x.EventId,
+                        principalTable: "Events",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_EventEventTopics_EventTopics_EventTopicId",
+                        column: x => x.EventTopicId,
+                        principalTable: "EventTopics",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
@@ -181,6 +224,33 @@ namespace HackYeah2025.Migrations
                 });
 
             migrationBuilder.InsertData(
+                table: "Events",
+                columns: new[] { "Id", "Address", "City", "DateFrom", "DateTo", "Latitude", "LongDescription", "Longitude", "Name", "Place", "ShortDescription" },
+                values: new object[]
+                {
+                    new Guid("2b4ae59e-7adf-4a95-a410-9ec118984d47"),
+                    "ul. Przemian 4",
+                    "Warszawa",
+                    new DateTimeOffset(new DateTime(2025, 4, 10, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                    new DateTimeOffset(new DateTime(2025, 4, 12, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                    50.067930m,
+                    "Civic Lab 2025 to intensywny proces projektowy, w którym zespoły młodzieżowe pracują z mentorami nad realnymi wyzwaniami miast. Uczestnicy przejdą przez etap diagnozy problemu, prototypowania rozwiązań oraz przygotowania prezentacji przed jury złożonym z przedstawicieli samorządów i organizacji społecznych.",
+                    19.983189m,
+                    "Civic Lab 2025",
+                    "Centrum Innowacji Młodych",
+                    "Trzydniowe laboratorium projektowe, w trakcie którego młodzież tworzy rozwiązania dla wyzwań lokalnych."
+                });
+
+            migrationBuilder.InsertData(
+                table: "EventTopics",
+                columns: new[] { "Id", "Name" },
+                values: new object[,]
+                {
+                    { new Guid("3acb29ab-38b3-4ce3-89ad-2fd25ed4a51c"), "innowacje społeczne" },
+                    { new Guid("d46920c0-0b77-4a0e-8c1f-9af70906cb60"), "edukacja obywatelska" }
+                });
+
+            migrationBuilder.InsertData(
                 table: "Volunteers",
                 columns: new[] { "Id", "Availability", "Description", "Email", "FirstName", "Languages", "LastName", "Phone", "PreferredRoles", "Skills", "Transport" },
                 values: new object[] { new Guid("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8"), new Dictionary<string, string> { ["tuesday_thursday"] = "Wtorki i czwartki 16:00 – 20:00", ["weekends"] = "Weekendy według ustaleń" }, "Doświadczona wolontariuszka wspierająca projekty międzypokoleniowe oraz wydarzenia edukacyjne.", "julia.nowak@mlodzidzialaja.pl", "Julia", new Dictionary<string, string> { ["Polski"] = "C2", ["Angielski"] = "C1", ["Ukraiński"] = "B1" }, "Nowak", "+48 511 222 333", "Koordynacja wolontariuszy, prowadzenie warsztatów, moderacja spotkań", new Dictionary<string, string> { ["Komunikacja i moderacja"] = "Zaawansowany", ["Animacja czasu wolnego"] = "Średniozaawansowany", ["Pierwsza pomoc"] = "Podstawowy", ["Planowanie wydarzeń"] = "Zaawansowany" }, "Rower, komunikacja miejska, możliwość dojazdu do 20 km" });
@@ -200,6 +270,15 @@ namespace HackYeah2025.Migrations
                 });
 
             migrationBuilder.InsertData(
+                table: "EventEventTopics",
+                columns: new[] { "EventId", "EventTopicId" },
+                values: new object[,]
+                {
+                    { new Guid("2b4ae59e-7adf-4a95-a410-9ec118984d47"), new Guid("3acb29ab-38b3-4ce3-89ad-2fd25ed4a51c") },
+                    { new Guid("2b4ae59e-7adf-4a95-a410-9ec118984d47"), new Guid("d46920c0-0b77-4a0e-8c1f-9af70906cb60") }
+                });
+
+            migrationBuilder.InsertData(
                 table: "VolunteerTags",
                 columns: new[] { "TagId", "VolunteerId" },
                 values: new object[,]
@@ -209,6 +288,11 @@ namespace HackYeah2025.Migrations
                     { new Guid("1d8cb68b-20da-4c4c-93f0-326f0f7a086b"), new Guid("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8") },
                     { new Guid("9a3e0ca5-579f-49ba-a479-76a519e5c08a"), new Guid("9f064bb8-162d-4e49-88f5-2e5f5f9a7ab8") }
                 });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EventEventTopics_EventTopicId",
+                table: "EventEventTopics",
+                column: "EventTopicId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Organizers_OrganizationId",
@@ -241,6 +325,9 @@ namespace HackYeah2025.Migrations
                 name: "Task");
 
             migrationBuilder.DropTable(
+                name: "EventEventTopics");
+
+            migrationBuilder.DropTable(
                 name: "VolunteerDistinctions");
 
             migrationBuilder.DropTable(
@@ -248,6 +335,9 @@ namespace HackYeah2025.Migrations
 
             migrationBuilder.DropTable(
                 name: "Organizations");
+
+            migrationBuilder.DropTable(
+                name: "EventTopics");
 
             migrationBuilder.DropTable(
                 name: "Events");

--- a/backend/HackYeah2025.Backend/HackYeah2025/Migrations/HackYeahDbContextModelSnapshot.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Migrations/HackYeahDbContextModelSnapshot.cs
@@ -29,19 +29,66 @@ namespace HackYeah2025.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
+                    b.Property<string>("Address")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("City")
+                        .IsRequired()
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
+
                     b.Property<DateTimeOffset>("DateFrom")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset>("DateTo")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("Title")
+                    b.Property<decimal>("Latitude")
+                        .HasColumnType("numeric(9,6)");
+
+                    b.Property<string>("LongDescription")
                         .IsRequired()
                         .HasColumnType("text");
+
+                    b.Property<decimal>("Longitude")
+                        .HasColumnType("numeric(9,6)");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("Place")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("ShortDescription")
+                        .IsRequired()
+                        .HasMaxLength(1024)
+                        .HasColumnType("character varying(1024)");
 
                     b.HasKey("Id");
 
                     b.ToTable("Events");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = new Guid("2b4ae59e-7adf-4a95-a410-9ec118984d47"),
+                            Address = "ul. Przemian 4",
+                            City = "Warszawa",
+                            DateFrom = new DateTimeOffset(new DateTime(2025, 4, 10, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                            DateTo = new DateTimeOffset(new DateTime(2025, 4, 12, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                            Latitude = 50.067930m,
+                            LongDescription = "Civic Lab 2025 to intensywny proces projektowy, w którym zespoły młodzieżowe pracują z mentorami nad realnymi wyzwaniami miast. Uczestnicy przejdą przez etap diagnozy problemu, prototypowania rozwiązań oraz przygotowania prezentacji przed jury złożonym z przedstawicieli samorządów i organizacji społecznych.",
+                            Longitude = 19.983189m,
+                            Name = "Civic Lab 2025",
+                            Place = "Centrum Innowacji Młodych",
+                            ShortDescription = "Trzydniowe laboratorium projektowe, w trakcie którego młodzież tworzy rozwiązania dla wyzwań lokalnych."
+                        });
                 });
 
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Organization", b =>
@@ -189,6 +236,61 @@ namespace HackYeah2025.Migrations
                         {
                             Id = new Guid("1d8cb68b-20da-4c4c-93f0-326f0f7a086b"),
                             Name = "Edukacja obywatelska"
+                        });
+                });
+
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.EventTopic", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("EventTopics");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = new Guid("3acb29ab-38b3-4ce3-89ad-2fd25ed4a51c"),
+                            Name = "innowacje społeczne"
+                        },
+                        new
+                        {
+                            Id = new Guid("d46920c0-0b77-4a0e-8c1f-9af70906cb60"),
+                            Name = "edukacja obywatelska"
+                        });
+                });
+
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.EventEventTopic", b =>
+                {
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("EventTopicId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("EventId", "EventTopicId");
+
+                    b.HasIndex("EventTopicId");
+
+                    b.ToTable("EventEventTopics");
+
+                    b.HasData(
+                        new
+                        {
+                            EventId = new Guid("2b4ae59e-7adf-4a95-a410-9ec118984d47"),
+                            EventTopicId = new Guid("3acb29ab-38b3-4ce3-89ad-2fd25ed4a51c")
+                        },
+                        new
+                        {
+                            EventId = new Guid("2b4ae59e-7adf-4a95-a410-9ec118984d47"),
+                            EventTopicId = new Guid("d46920c0-0b77-4a0e-8c1f-9af70906cb60")
                         });
                 });
 
@@ -381,6 +483,25 @@ namespace HackYeah2025.Migrations
                         .IsRequired();
                 });
 
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.EventEventTopic", b =>
+                {
+                    b.HasOne("HackYeah2025.Infrastructure.Models.Event", "Event")
+                        .WithMany("EventEventTopics")
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("HackYeah2025.Infrastructure.Models.EventTopic", "EventTopic")
+                        .WithMany("EventEventTopics")
+                        .HasForeignKey("EventTopicId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Event");
+
+                    b.Navigation("EventTopic");
+                });
+
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.VolunteerDistinction", b =>
                 {
                     b.HasOne("HackYeah2025.Infrastructure.Models.Volunteer", "Volunteer")
@@ -413,7 +534,14 @@ namespace HackYeah2025.Migrations
 
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Event", b =>
                 {
+                    b.Navigation("EventEventTopics");
+
                     b.Navigation("Tasks");
+                });
+
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.EventTopic", b =>
+                {
+                    b.Navigation("EventEventTopics");
                 });
 
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Organization", b =>

--- a/backend/HackYeah2025.Backend/HackYeah2025/Program.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddDbContext<HackYeahDbContext>(o =>
 builder.Services.AddScoped<IOrganizationService, OrganizationService>();
 builder.Services.AddScoped<IOrganizerService, OrganizerService>();
 builder.Services.AddScoped<IVolunteerService, VolunteerService>();
+builder.Services.AddScoped<IEventService, EventService>();
 
 WebApplication app = builder.Build();
 


### PR DESCRIPTION
## Summary
- extend the event entity with detailed location and description fields and seed the Civic Lab 2025 data
- introduce event topic dictionary entities with seeding and wire them into the DbContext and initial migration
- add an event service, register it in DI, and expose a GET endpoint for retrieving events by id

## Testing
- dotnet test *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e159dd0c148320b687dd737a9220c0