### PR TITLE
Implement typed registration flow

### DIFF
--- a/backend/HackYeah2025.Backend/HackYeah2025/Features/Auth/AuthContracts.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Features/Auth/AuthContracts.cs
@@ -22,6 +22,121 @@ public record RegisterRequest
     public Guid? VolunteerId { get; init; }
 
     public Guid? OrganizerId { get; init; }
+
+    public Guid? CoordinatorId { get; init; }
+
+    [MaxLength(64)]
+    public string AccountType { get; init; } = string.Empty;
+
+    public VolunteerRegistration? VolunteerProfile { get; init; }
+
+    public OrganizerRegistration? OrganizerProfile { get; init; }
+
+    public CoordinatorRegistration? CoordinatorProfile { get; init; }
+}
+
+public record VolunteerRegistration
+{
+    [Required]
+    [MaxLength(128)]
+    public string FirstName { get; init; } = string.Empty;
+
+    [Required]
+    [MaxLength(128)]
+    public string LastName { get; init; } = string.Empty;
+
+    [Required]
+    [MaxLength(1024)]
+    public string Description { get; init; } = string.Empty;
+
+    [MaxLength(512)]
+    public string PreferredRoles { get; init; } = string.Empty;
+
+    [MaxLength(512)]
+    public string Availability { get; init; } = string.Empty;
+
+    [MaxLength(512)]
+    public string Languages { get; init; } = string.Empty;
+
+    [MaxLength(512)]
+    public string Skills { get; init; } = string.Empty;
+
+    [MaxLength(256)]
+    public string Transport { get; init; } = string.Empty;
+
+    [MaxLength(256)]
+    public string Email { get; init; } = string.Empty;
+
+    [MaxLength(64)]
+    public string Phone { get; init; } = string.Empty;
+}
+
+public record OrganizerRegistration
+{
+    [Required]
+    [MaxLength(256)]
+    public string FullName { get; init; } = string.Empty;
+
+    [Required]
+    [MaxLength(256)]
+    public string Role { get; init; } = string.Empty;
+
+    [MaxLength(64)]
+    public string Phone { get; init; } = string.Empty;
+
+    [MaxLength(256)]
+    public string Email { get; init; } = string.Empty;
+
+    [MaxLength(256)]
+    public string Languages { get; init; } = string.Empty;
+
+    [MaxLength(512)]
+    public string Specializations { get; init; } = string.Empty;
+
+    [Required]
+    public OrganizationRegistration? Organization { get; init; }
+}
+
+public record OrganizationRegistration
+{
+    [Required]
+    [MaxLength(256)]
+    public string Name { get; init; } = string.Empty;
+
+    [Required]
+    [MaxLength(16)]
+    public string FoundedYear { get; init; } = string.Empty;
+
+    [Required]
+    [MaxLength(512)]
+    public string Location { get; init; } = string.Empty;
+
+    [Required]
+    [MaxLength(1024)]
+    public string Programs { get; init; } = string.Empty;
+
+    [Required]
+    [MaxLength(1024)]
+    public string Mission { get; init; } = string.Empty;
+
+    [Required]
+    [MaxLength(256)]
+    public string Website { get; init; } = string.Empty;
+}
+
+public record CoordinatorRegistration
+{
+    [Required]
+    [MaxLength(128)]
+    public string FirstName { get; init; } = string.Empty;
+
+    [Required]
+    [MaxLength(128)]
+    public string LastName { get; init; } = string.Empty;
+
+    [Required]
+    [MaxLength(1024)]
+    public string Description { get; init; } = string.Empty;
 }
 
 public record LoginRequest

--- a/backend/HackYeah2025.Backend/HackYeah2025/Features/Auth/AuthService.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Features/Auth/AuthService.cs
@@ -5,7 +5,9 @@ using HackYeah2025.Infrastructure.Security;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Security.Claims;
 using System.Text;
 
@@ -34,11 +36,9 @@ public class AuthService : IAuthService
     {
         string normalizedLogin = request.Login.Trim();
         string normalizedEmail = request.Email.Trim().ToLowerInvariant();
+        RegistrationAccountType? accountType = ParseAccountType(request.AccountType);
 
-        if (request.VolunteerId.HasValue && request.OrganizerId.HasValue)
-        {
-            throw new InvalidOperationException("MultipleProfilesNotSupported");
-        }
+        EnsureSingleProfileSelection(request, accountType);
 
         bool loginExists = await _dbContext.Accounts.AnyAsync(a => a.Login == normalizedLogin, cancellationToken);
         if (loginExists)
@@ -52,10 +52,14 @@ public class AuthService : IAuthService
             throw new InvalidOperationException("EmailAlreadyExists");
         }
 
+        Guid? volunteerId = request.VolunteerId;
+        Guid? organizerId = request.OrganizerId;
+        Guid? coordinatorId = request.CoordinatorId;
+
         Volunteer? volunteer = null;
-        if (request.VolunteerId.HasValue)
+        if (volunteerId.HasValue)
         {
-            volunteer = await _dbContext.Volunteers.Include(v => v.Account).FirstOrDefaultAsync(v => v.Id == request.VolunteerId.Value, cancellationToken);
+            volunteer = await _dbContext.Volunteers.Include(v => v.Account).FirstOrDefaultAsync(v => v.Id == volunteerId.Value, cancellationToken);
             if (volunteer is null)
             {
                 throw new InvalidOperationException("VolunteerNotFound");
@@ -68,9 +72,9 @@ public class AuthService : IAuthService
         }
 
         Organizer? organizer = null;
-        if (request.OrganizerId.HasValue)
+        if (organizerId.HasValue)
         {
-            organizer = await _dbContext.Organizers.Include(o => o.Account).FirstOrDefaultAsync(o => o.Id == request.OrganizerId.Value, cancellationToken);
+            organizer = await _dbContext.Organizers.Include(o => o.Account).FirstOrDefaultAsync(o => o.Id == organizerId.Value, cancellationToken);
             if (organizer is null)
             {
                 throw new InvalidOperationException("OrganizerNotFound");
@@ -82,7 +86,111 @@ public class AuthService : IAuthService
             }
         }
 
-        List<string> requestedRoles = request.Roles.Count > 0 ? request.Roles : new List<string> { DbRoleEntityTypeConfiguration.Volunteer.Name };
+        Coordinator? coordinator = null;
+        if (coordinatorId.HasValue)
+        {
+            coordinator = await _dbContext.Coordinators.Include(c => c.Account).FirstOrDefaultAsync(c => c.Id == coordinatorId.Value, cancellationToken);
+            if (coordinator is null)
+            {
+                throw new InvalidOperationException("CoordinatorNotFound");
+            }
+
+            if (coordinator.Account is not null)
+            {
+                throw new InvalidOperationException("CoordinatorAlreadyLinked");
+            }
+        }
+
+        if (accountType is null)
+        {
+            accountType = InferAccountType(volunteerId, organizerId, coordinatorId, request);
+        }
+
+        if (accountType == RegistrationAccountType.Volunteer && !volunteerId.HasValue)
+        {
+            VolunteerRegistration profile = request.VolunteerProfile ?? throw new InvalidOperationException("VolunteerProfileRequired");
+            string volunteerEmail = string.IsNullOrWhiteSpace(profile.Email) ? normalizedEmail : profile.Email.Trim().ToLowerInvariant();
+            string volunteerPhone = NormalizeOrThrow(profile.Phone, "VolunteerPhoneRequired");
+
+            volunteer = new Volunteer
+            {
+                Id = Guid.NewGuid(),
+                FirstName = profile.FirstName.Trim(),
+                LastName = profile.LastName.Trim(),
+                Description = profile.Description.Trim(),
+                Availability = CreateDictionaryFromText(profile.Availability, "availability"),
+                PreferredRoles = EnsureValueOrFallback(profile.PreferredRoles, "Do ustalenia"),
+                Languages = CreateDictionaryFromText(profile.Languages, "language"),
+                Transport = EnsureValueOrFallback(profile.Transport, "Do ustalenia"),
+                Skills = CreateDictionaryFromText(profile.Skills, "skill"),
+                Email = volunteerEmail,
+                Phone = volunteerPhone
+            };
+
+            _dbContext.Volunteers.Add(volunteer);
+            volunteerId = volunteer.Id;
+        }
+
+        Organization? organization = null;
+        if (accountType == RegistrationAccountType.Organizer && !organizerId.HasValue)
+        {
+            OrganizerRegistration organizerProfile = request.OrganizerProfile ?? throw new InvalidOperationException("OrganizerProfileRequired");
+            OrganizationRegistration organizationProfile = organizerProfile.Organization ?? throw new InvalidOperationException("OrganizationProfileRequired");
+
+            if (!int.TryParse(organizationProfile.FoundedYear, NumberStyles.Integer, CultureInfo.InvariantCulture, out int foundedYear))
+            {
+                throw new InvalidOperationException("InvalidOrganizationFoundedYear");
+            }
+
+            organization = new Organization
+            {
+                Id = Guid.NewGuid(),
+                Name = organizationProfile.Name.Trim(),
+                FoundedYear = foundedYear,
+                Location = organizationProfile.Location.Trim(),
+                Programs = organizationProfile.Programs.Trim(),
+                Mission = organizationProfile.Mission.Trim(),
+                Website = organizationProfile.Website.Trim()
+            };
+
+            _dbContext.Organizations.Add(organization);
+
+            string organizerEmail = string.IsNullOrWhiteSpace(organizerProfile.Email) ? normalizedEmail : organizerProfile.Email.Trim().ToLowerInvariant();
+
+            organizer = new Organizer
+            {
+                Id = Guid.NewGuid(),
+                OrganizationId = organization.Id,
+                FullName = organizerProfile.FullName.Trim(),
+                Role = organizerProfile.Role.Trim(),
+                Phone = EnsureValueOrFallback(organizerProfile.Phone, "Do ustalenia"),
+                Email = organizerEmail,
+                Languages = EnsureValueOrFallback(organizerProfile.Languages, "Do ustalenia"),
+                Specializations = EnsureValueOrFallback(organizerProfile.Specializations, "Do ustalenia"),
+                Organization = organization
+            };
+
+            _dbContext.Organizers.Add(organizer);
+            organizerId = organizer.Id;
+        }
+
+        if (accountType == RegistrationAccountType.Coordinator && !coordinatorId.HasValue)
+        {
+            CoordinatorRegistration coordinatorProfile = request.CoordinatorProfile ?? throw new InvalidOperationException("CoordinatorProfileRequired");
+
+            coordinator = new Coordinator
+            {
+                Id = Guid.NewGuid(),
+                FirstName = coordinatorProfile.FirstName.Trim(),
+                LastName = coordinatorProfile.LastName.Trim(),
+                Description = coordinatorProfile.Description.Trim()
+            };
+
+            _dbContext.Coordinators.Add(coordinator);
+            coordinatorId = coordinator.Id;
+        }
+
+        List<string> requestedRoles = request.Roles.Count > 0 ? request.Roles : GetDefaultRoles(accountType, volunteerId, organizerId, coordinatorId);
         HashSet<string> normalizedRoles = requestedRoles
             .Select(r => r.Trim())
             .Where(r => !string.IsNullOrWhiteSpace(r))
@@ -90,7 +198,7 @@ public class AuthService : IAuthService
 
         if (normalizedRoles.Count == 0)
         {
-            normalizedRoles.Add(DbRoleEntityTypeConfiguration.Volunteer.Name);
+            normalizedRoles.UnionWith(GetDefaultRoles(accountType, volunteerId, organizerId, coordinatorId));
         }
 
         List<Role> roles = await _dbContext.Roles
@@ -109,8 +217,9 @@ public class AuthService : IAuthService
             Email = normalizedEmail,
             PasswordHash = PasswordHasher.Hash(request.Password),
             IsActive = true,
-            VolunteerId = request.VolunteerId,
-            OrganizerId = request.OrganizerId,
+            VolunteerId = volunteerId,
+            OrganizerId = organizerId,
+            CoordinatorId = coordinatorId,
             AccountRoles = roles.Select(role => new AccountRole
             {
                 RoleId = role.Id
@@ -191,5 +300,130 @@ public class AuthService : IAuthService
             Email = account.Email,
             Roles = roles.Select(role => role.Name).ToList()
         };
+    }
+
+    private static void EnsureSingleProfileSelection(RegisterRequest request, RegistrationAccountType? accountType)
+    {
+        int selections = 0;
+
+        if (request.VolunteerId.HasValue || request.VolunteerProfile is not null || accountType == RegistrationAccountType.Volunteer)
+        {
+            selections++;
+        }
+
+        if (request.OrganizerId.HasValue || request.OrganizerProfile is not null || accountType == RegistrationAccountType.Organizer)
+        {
+            selections++;
+        }
+
+        if (request.CoordinatorId.HasValue || request.CoordinatorProfile is not null || accountType == RegistrationAccountType.Coordinator)
+        {
+            selections++;
+        }
+
+        if (selections > 1)
+        {
+            throw new InvalidOperationException("MultipleProfilesNotSupported");
+        }
+    }
+
+    private static RegistrationAccountType? InferAccountType(Guid? volunteerId, Guid? organizerId, Guid? coordinatorId, RegisterRequest request)
+    {
+        if (volunteerId.HasValue || request.VolunteerProfile is not null)
+        {
+            return RegistrationAccountType.Volunteer;
+        }
+
+        if (organizerId.HasValue || request.OrganizerProfile is not null)
+        {
+            return RegistrationAccountType.Organizer;
+        }
+
+        if (coordinatorId.HasValue || request.CoordinatorProfile is not null)
+        {
+            return RegistrationAccountType.Coordinator;
+        }
+
+        return null;
+    }
+
+    private static RegistrationAccountType? ParseAccountType(string accountType)
+    {
+        if (string.IsNullOrWhiteSpace(accountType))
+        {
+            return null;
+        }
+
+        return accountType.Trim().ToLowerInvariant() switch
+        {
+            "wolontariusz" or "volunteer" => RegistrationAccountType.Volunteer,
+            "organizator" or "organizer" => RegistrationAccountType.Organizer,
+            "koordynator" or "coordinator" => RegistrationAccountType.Coordinator,
+            _ => throw new InvalidOperationException("AccountTypeNotSupported")
+        };
+    }
+
+    private static List<string> GetDefaultRoles(RegistrationAccountType? accountType, Guid? volunteerId, Guid? organizerId, Guid? coordinatorId)
+    {
+        if (accountType == RegistrationAccountType.Organizer || organizerId.HasValue)
+        {
+            return new List<string> { DbRoleEntityTypeConfiguration.Organizer.Name };
+        }
+
+        if (accountType == RegistrationAccountType.Coordinator || coordinatorId.HasValue)
+        {
+            return new List<string> { DbRoleEntityTypeConfiguration.Coordinator.Name };
+        }
+
+        return new List<string> { DbRoleEntityTypeConfiguration.Volunteer.Name };
+    }
+
+    private static Dictionary<string, string> CreateDictionaryFromText(string value, string prefix)
+    {
+        Dictionary<string, string> dictionary = new(StringComparer.InvariantCultureIgnoreCase);
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            dictionary[$"{prefix}_1"] = "Do ustalenia";
+            return dictionary;
+        }
+
+        string[] segments = value
+            .Split(new[] { '\n', ',' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (segments.Length == 0)
+        {
+            dictionary[$"{prefix}_1"] = value.Trim();
+            return dictionary;
+        }
+
+        for (int index = 0; index < segments.Length; index++)
+        {
+            dictionary[$"{prefix}_{index + 1}"] = segments[index];
+        }
+
+        return dictionary;
+    }
+
+    private static string EnsureValueOrFallback(string value, string fallback)
+    {
+        return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+    }
+
+    private static string NormalizeOrThrow(string value, string errorCode)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(errorCode);
+        }
+
+        return value.Trim();
+    }
+
+    private enum RegistrationAccountType
+    {
+        Volunteer,
+        Organizer,
+        Coordinator
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/HackYeahDbContext.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/HackYeahDbContext.cs
@@ -8,6 +8,7 @@ public sealed class HackYeahDbContext : DbContext
     public DbSet<Event> Events { get; set; }
     public DbSet<Organization> Organizations { get; set; }
     public DbSet<Organizer> Organizers { get; set; }
+    public DbSet<Coordinator> Coordinators { get; set; }
     public DbSet<Volunteer> Volunteers { get; set; }
     public DbSet<Tag> Tags { get; set; }
     public DbSet<VolunteerTag> VolunteerTags { get; set; }
@@ -29,6 +30,7 @@ public sealed class HackYeahDbContext : DbContext
         modelBuilder.ApplyConfiguration(new DbEventEntityTypeConfiguration());
         modelBuilder.ApplyConfiguration(new DbOrganizationEntityTypeConfiguration());
         modelBuilder.ApplyConfiguration(new DbOrganizerEntityTypeConfiguration());
+        modelBuilder.ApplyConfiguration(new DbCoordinatorEntityTypeConfiguration());
         modelBuilder.ApplyConfiguration(new DbVolunteerEntityTypeConfiguration());
         modelBuilder.ApplyConfiguration(new DbTagEntityTypeConfiguration());
         modelBuilder.ApplyConfiguration(new DbVolunteerTagEntityTypeConfiguration());

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Account.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Account.cs
@@ -15,6 +15,8 @@ public class Account
     public Volunteer? Volunteer { get; set; }
     public Guid? OrganizerId { get; set; }
     public Organizer? Organizer { get; set; }
+    public Guid? CoordinatorId { get; set; }
+    public Coordinator? Coordinator { get; set; }
     public ICollection<AccountRole> AccountRoles { get; set; } = new List<AccountRole>();
 }
 
@@ -47,6 +49,11 @@ public class DbAccountEntityTypeConfiguration : IEntityTypeConfiguration<Account
         builder.HasOne(a => a.Organizer)
             .WithOne(o => o.Account)
             .HasForeignKey<Account>(a => a.OrganizerId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasOne(a => a.Coordinator)
+            .WithOne(c => c.Account)
+            .HasForeignKey<Account>(a => a.CoordinatorId)
             .OnDelete(DeleteBehavior.SetNull);
     }
 }

--- a/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Coordinator.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Infrastructure/Models/Coordinator.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HackYeah2025.Infrastructure.Models;
+
+public class Coordinator
+{
+    public Guid Id { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public Account? Account { get; set; }
+}
+
+public class DbCoordinatorEntityTypeConfiguration : IEntityTypeConfiguration<Coordinator>
+{
+    public void Configure(EntityTypeBuilder<Coordinator> builder)
+    {
+        builder.ToTable("Coordinators");
+        builder.HasKey(c => c.Id);
+        builder.Property(c => c.FirstName).IsRequired().HasMaxLength(128);
+        builder.Property(c => c.LastName).IsRequired().HasMaxLength(128);
+        builder.Property(c => c.Description).IsRequired().HasMaxLength(1024);
+
+        builder.HasOne(c => c.Account)
+            .WithOne(a => a.Coordinator)
+            .HasForeignKey<Account>(a => a.CoordinatorId);
+    }
+}

--- a/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251005180000_AddCoordinatorRegistration.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Migrations/20251005180000_AddCoordinatorRegistration.cs
@@ -1,0 +1,68 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HackYeah2025.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCoordinatorRegistration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "CoordinatorId",
+                table: "Accounts",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Coordinators",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    FirstName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    LastName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Coordinators", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Accounts_CoordinatorId",
+                table: "Accounts",
+                column: "CoordinatorId",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Accounts_Coordinators_CoordinatorId",
+                table: "Accounts",
+                column: "CoordinatorId",
+                principalTable: "Coordinators",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Accounts_Coordinators_CoordinatorId",
+                table: "Accounts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Accounts_CoordinatorId",
+                table: "Accounts");
+
+            migrationBuilder.DropTable(
+                name: "Coordinators");
+
+            migrationBuilder.DropColumn(
+                name: "CoordinatorId",
+                table: "Accounts");
+        }
+    }
+}

--- a/backend/HackYeah2025.Backend/HackYeah2025/Migrations/HackYeahDbContextModelSnapshot.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Migrations/HackYeahDbContextModelSnapshot.cs
@@ -47,6 +47,9 @@ namespace HackYeah2025.Migrations
                         .HasMaxLength(128)
                         .HasColumnType("character varying(128)");
 
+                    b.Property<Guid?>("CoordinatorId")
+                        .HasColumnType("uuid");
+
                     b.Property<Guid?>("OrganizerId")
                         .HasColumnType("uuid");
 
@@ -59,6 +62,9 @@ namespace HackYeah2025.Migrations
                         .HasColumnType("uuid");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("CoordinatorId")
+                        .IsUnique();
 
                     b.HasIndex("Email")
                         .IsUnique();
@@ -88,6 +94,32 @@ namespace HackYeah2025.Migrations
                     b.HasIndex("RoleId");
 
                     b.ToTable("AccountRoles", (string)null);
+                });
+
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Coordinator", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasMaxLength(1024)
+                        .HasColumnType("character varying(1024)");
+
+                    b.Property<string>("FirstName")
+                        .IsRequired()
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
+
+                    b.Property<string>("LastName")
+                        .IsRequired()
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Coordinators");
                 });
 
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Event", b =>
@@ -573,6 +605,11 @@ namespace HackYeah2025.Migrations
 
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Account", b =>
                 {
+                    b.HasOne("HackYeah2025.Infrastructure.Models.Coordinator", "Coordinator")
+                        .WithOne("Account")
+                        .HasForeignKey("HackYeah2025.Infrastructure.Models.Account", "CoordinatorId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
                     b.HasOne("HackYeah2025.Infrastructure.Models.Organizer", "Organizer")
                         .WithOne("Account")
                         .HasForeignKey("HackYeah2025.Infrastructure.Models.Account", "OrganizerId")
@@ -582,6 +619,8 @@ namespace HackYeah2025.Migrations
                         .WithOne("Account")
                         .HasForeignKey("HackYeah2025.Infrastructure.Models.Account", "VolunteerId")
                         .OnDelete(DeleteBehavior.SetNull);
+
+                    b.Navigation("Coordinator");
 
                     b.Navigation("Organizer");
 
@@ -679,6 +718,11 @@ namespace HackYeah2025.Migrations
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Account", b =>
                 {
                     b.Navigation("AccountRoles");
+                });
+
+            modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Coordinator", b =>
+                {
+                    b.Navigation("Account");
                 });
 
             modelBuilder.Entity("HackYeah2025.Infrastructure.Models.Event", b =>

--- a/frontend/src/pages/RegisterPage/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.jsx
@@ -1,12 +1,581 @@
+import { useState } from 'react'
 import styles from './RegisterPage.module.scss'
 
-export default function RegisterPage() {
+const userTypes = [
+    { value: 'volunteer', label: 'Wolontariusz' },
+    { value: 'organizer', label: 'Organizator' },
+    { value: 'coordinator', label: 'Koordynator' }
+]
 
+const defaultVolunteerData = {
+    firstName: '',
+    lastName: '',
+    phone: '',
+    description: '',
+    availability: '',
+    preferredRoles: '',
+    languages: '',
+    transport: '',
+    skills: ''
+}
+
+const defaultOrganizerData = {
+    fullName: '',
+    role: '',
+    phone: '',
+    email: '',
+    languages: '',
+    specializations: '',
+    organizationName: '',
+    organizationFoundedYear: '',
+    organizationLocation: '',
+    organizationPrograms: '',
+    organizationMission: '',
+    organizationWebsite: ''
+}
+
+const defaultCoordinatorData = {
+    firstName: '',
+    lastName: '',
+    description: ''
+}
+
+function buildRegisterPayload(type, commonData, volunteerData, organizerData, coordinatorData) {
+    const payload = {
+        login: commonData.login.trim(),
+        email: commonData.email.trim(),
+        password: commonData.password,
+        accountType: type,
+        roles: []
+    }
+
+    if (type === 'volunteer') {
+        payload.volunteerProfile = {
+            firstName: volunteerData.firstName.trim(),
+            lastName: volunteerData.lastName.trim(),
+            description: volunteerData.description.trim(),
+            phone: volunteerData.phone.trim(),
+            availability: volunteerData.availability,
+            preferredRoles: volunteerData.preferredRoles,
+            languages: volunteerData.languages,
+            transport: volunteerData.transport,
+            skills: volunteerData.skills,
+            email: commonData.email.trim()
+        }
+    }
+
+    if (type === 'organizer') {
+        payload.organizerProfile = {
+            fullName: organizerData.fullName.trim(),
+            role: organizerData.role.trim(),
+            phone: organizerData.phone.trim(),
+            email: (organizerData.email || commonData.email).trim(),
+            languages: organizerData.languages,
+            specializations: organizerData.specializations,
+            organization: {
+                name: organizerData.organizationName.trim(),
+                foundedYear: organizerData.organizationFoundedYear.trim(),
+                location: organizerData.organizationLocation.trim(),
+                programs: organizerData.organizationPrograms.trim(),
+                mission: organizerData.organizationMission.trim(),
+                website: organizerData.organizationWebsite.trim()
+            }
+        }
+    }
+
+    if (type === 'coordinator') {
+        payload.coordinatorProfile = {
+            firstName: coordinatorData.firstName.trim(),
+            lastName: coordinatorData.lastName.trim(),
+            description: coordinatorData.description.trim()
+        }
+    }
+
+    return payload
+}
+
+export default function RegisterPage() {
+    const [userType, setUserType] = useState(userTypes[0].value)
+    const [commonData, setCommonData] = useState({ login: '', email: '', password: '', confirmPassword: '' })
+    const [volunteerData, setVolunteerData] = useState(defaultVolunteerData)
+    const [organizerData, setOrganizerData] = useState(defaultOrganizerData)
+    const [coordinatorData, setCoordinatorData] = useState(defaultCoordinatorData)
+    const [status, setStatus] = useState({ type: '', message: '' })
+    const [isSubmitting, setIsSubmitting] = useState(false)
+
+    const handleTypeChange = (event) => {
+        setUserType(event.target.value)
+        setStatus({ type: '', message: '' })
+    }
+
+    const handleCommonChange = (event) => {
+        const { name, value } = event.target
+        setCommonData((prev) => ({ ...prev, [name]: value }))
+    }
+
+    const handleVolunteerChange = (event) => {
+        const { name, value } = event.target
+        setVolunteerData((prev) => ({ ...prev, [name]: value }))
+    }
+
+    const handleOrganizerChange = (event) => {
+        const { name, value } = event.target
+        setOrganizerData((prev) => ({ ...prev, [name]: value }))
+    }
+
+    const handleCoordinatorChange = (event) => {
+        const { name, value } = event.target
+        setCoordinatorData((prev) => ({ ...prev, [name]: value }))
+    }
+
+    const handleSubmit = async (event) => {
+        event.preventDefault()
+
+        if (commonData.password !== commonData.confirmPassword) {
+            setStatus({ type: 'error', message: 'Hasła nie są zgodne.' })
+            return
+        }
+
+        setIsSubmitting(true)
+        setStatus({ type: '', message: '' })
+
+        const payload = buildRegisterPayload(userType, commonData, volunteerData, organizerData, coordinatorData)
+
+        try {
+            const response = await fetch('/api/auth/register', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            })
+
+            if (!response.ok) {
+                const errorBody = await response.json().catch(() => null)
+                const errorMessage = errorBody?.error ?? 'Wystąpił błąd podczas rejestracji.'
+                throw new Error(errorMessage)
+            }
+
+            setStatus({ type: 'success', message: 'Konto zostało utworzone. Możesz się teraz zalogować.' })
+        } catch (error) {
+            setStatus({ type: 'error', message: error.message || 'Wystąpił błąd podczas rejestracji.' })
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    const renderVolunteerFields = () => (
+        <fieldset className={styles.fieldset}>
+            <legend className={styles.legend}>Dane wolontariusza</legend>
+            <div className={styles.fieldGrid}>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="volunteer-firstName">Imię</label>
+                    <input
+                        id="volunteer-firstName"
+                        name="firstName"
+                        className={styles.input}
+                        value={volunteerData.firstName}
+                        onChange={handleVolunteerChange}
+                        required
+                        autoComplete="given-name"
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="volunteer-lastName">Nazwisko</label>
+                    <input
+                        id="volunteer-lastName"
+                        name="lastName"
+                        className={styles.input}
+                        value={volunteerData.lastName}
+                        onChange={handleVolunteerChange}
+                        required
+                        autoComplete="family-name"
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="volunteer-phone">Telefon</label>
+                    <input
+                        id="volunteer-phone"
+                        name="phone"
+                        className={styles.input}
+                        value={volunteerData.phone}
+                        onChange={handleVolunteerChange}
+                        required
+                        autoComplete="tel"
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="volunteer-transport">Transport</label>
+                    <input
+                        id="volunteer-transport"
+                        name="transport"
+                        className={styles.input}
+                        value={volunteerData.transport}
+                        onChange={handleVolunteerChange}
+                        placeholder="Np. komunikacja miejska, rower"
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="volunteer-preferredRoles">Preferowane role</label>
+                    <input
+                        id="volunteer-preferredRoles"
+                        name="preferredRoles"
+                        className={styles.input}
+                        value={volunteerData.preferredRoles}
+                        onChange={handleVolunteerChange}
+                        placeholder="Wpisz najważniejsze zadania, które Cię interesują"
+                    />
+                </div>
+            </div>
+            <div className={styles.field}>
+                <label className={styles.label} htmlFor="volunteer-description">Krótki opis</label>
+                <textarea
+                    id="volunteer-description"
+                    name="description"
+                    className={styles.textarea}
+                    value={volunteerData.description}
+                    onChange={handleVolunteerChange}
+                    required
+                    placeholder="Opisz swoje doświadczenie i motywację"
+                />
+            </div>
+            <div className={styles.field}>
+                <label className={styles.label} htmlFor="volunteer-availability">Dostępność</label>
+                <textarea
+                    id="volunteer-availability"
+                    name="availability"
+                    className={styles.textarea}
+                    value={volunteerData.availability}
+                    onChange={handleVolunteerChange}
+                    placeholder="Opisz dni i godziny, kiedy możesz działać"
+                />
+                <span className={styles.note}>Możesz wpisać kilka pozycji, rozdzielając je enterami.</span>
+            </div>
+            <div className={styles.field}>
+                <label className={styles.label} htmlFor="volunteer-languages">Języki</label>
+                <textarea
+                    id="volunteer-languages"
+                    name="languages"
+                    className={styles.textarea}
+                    value={volunteerData.languages}
+                    onChange={handleVolunteerChange}
+                    placeholder="Np. polski (C1), angielski (B2)"
+                />
+            </div>
+            <div className={styles.field}>
+                <label className={styles.label} htmlFor="volunteer-skills">Umiejętności</label>
+                <textarea
+                    id="volunteer-skills"
+                    name="skills"
+                    className={styles.textarea}
+                    value={volunteerData.skills}
+                    onChange={handleVolunteerChange}
+                    placeholder="Wymień swoje najważniejsze umiejętności"
+                />
+            </div>
+        </fieldset>
+    )
+
+    const renderOrganizerFields = () => (
+        <fieldset className={styles.fieldset}>
+            <legend className={styles.legend}>Dane organizatora</legend>
+            <div className={styles.fieldGrid}>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="organizer-fullName">Imię i nazwisko</label>
+                    <input
+                        id="organizer-fullName"
+                        name="fullName"
+                        className={styles.input}
+                        value={organizerData.fullName}
+                        onChange={handleOrganizerChange}
+                        required
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="organizer-role">Rola w organizacji</label>
+                    <input
+                        id="organizer-role"
+                        name="role"
+                        className={styles.input}
+                        value={organizerData.role}
+                        onChange={handleOrganizerChange}
+                        required
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="organizer-phone">Telefon</label>
+                    <input
+                        id="organizer-phone"
+                        name="phone"
+                        className={styles.input}
+                        value={organizerData.phone}
+                        onChange={handleOrganizerChange}
+                        required
+                        autoComplete="tel"
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="organizer-email">Adres e-mail</label>
+                    <input
+                        id="organizer-email"
+                        name="email"
+                        className={styles.input}
+                        value={organizerData.email}
+                        onChange={handleOrganizerChange}
+                        placeholder="Jeśli inny niż logowania"
+                        autoComplete="email"
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="organizer-languages">Języki</label>
+                    <input
+                        id="organizer-languages"
+                        name="languages"
+                        className={styles.input}
+                        value={organizerData.languages}
+                        onChange={handleOrganizerChange}
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="organizer-specializations">Specjalizacje</label>
+                    <input
+                        id="organizer-specializations"
+                        name="specializations"
+                        className={styles.input}
+                        value={organizerData.specializations}
+                        onChange={handleOrganizerChange}
+                    />
+                </div>
+            </div>
+            <div className={styles.fieldGrid}>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="organization-name">Nazwa organizacji</label>
+                    <input
+                        id="organization-name"
+                        name="organizationName"
+                        className={styles.input}
+                        value={organizerData.organizationName}
+                        onChange={handleOrganizerChange}
+                        required
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="organization-foundedYear">Rok założenia</label>
+                    <input
+                        id="organization-foundedYear"
+                        name="organizationFoundedYear"
+                        className={styles.input}
+                        value={organizerData.organizationFoundedYear}
+                        onChange={handleOrganizerChange}
+                        required
+                        inputMode="numeric"
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="organization-website">Strona internetowa</label>
+                    <input
+                        id="organization-website"
+                        name="organizationWebsite"
+                        className={styles.input}
+                        value={organizerData.organizationWebsite}
+                        onChange={handleOrganizerChange}
+                        required
+                        autoComplete="url"
+                    />
+                </div>
+            </div>
+            <div className={styles.field}>
+                <label className={styles.label} htmlFor="organization-location">Lokalizacja</label>
+                <textarea
+                    id="organization-location"
+                    name="organizationLocation"
+                    className={styles.textarea}
+                    value={organizerData.organizationLocation}
+                    onChange={handleOrganizerChange}
+                    required
+                    placeholder="Adres siedziby lub obszar działania"
+                />
+            </div>
+            <div className={styles.field}>
+                <label className={styles.label} htmlFor="organization-programs">Programy</label>
+                <textarea
+                    id="organization-programs"
+                    name="organizationPrograms"
+                    className={styles.textarea}
+                    value={organizerData.organizationPrograms}
+                    onChange={handleOrganizerChange}
+                    required
+                    placeholder="Opisz główne programy i działania"
+                />
+            </div>
+            <div className={styles.field}>
+                <label className={styles.label} htmlFor="organization-mission">Misja</label>
+                <textarea
+                    id="organization-mission"
+                    name="organizationMission"
+                    className={styles.textarea}
+                    value={organizerData.organizationMission}
+                    onChange={handleOrganizerChange}
+                    required
+                    placeholder="W kilku zdaniach opisz misję organizacji"
+                />
+            </div>
+        </fieldset>
+    )
+
+    const renderCoordinatorFields = () => (
+        <fieldset className={styles.fieldset}>
+            <legend className={styles.legend}>Dane koordynatora</legend>
+            <div className={styles.fieldGrid}>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="coordinator-firstName">Imię</label>
+                    <input
+                        id="coordinator-firstName"
+                        name="firstName"
+                        className={styles.input}
+                        value={coordinatorData.firstName}
+                        onChange={handleCoordinatorChange}
+                        required
+                        autoComplete="given-name"
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="coordinator-lastName">Nazwisko</label>
+                    <input
+                        id="coordinator-lastName"
+                        name="lastName"
+                        className={styles.input}
+                        value={coordinatorData.lastName}
+                        onChange={handleCoordinatorChange}
+                        required
+                        autoComplete="family-name"
+                    />
+                </div>
+            </div>
+            <div className={styles.field}>
+                <label className={styles.label} htmlFor="coordinator-description">Opis</label>
+                <textarea
+                    id="coordinator-description"
+                    name="description"
+                    className={styles.textarea}
+                    value={coordinatorData.description}
+                    onChange={handleCoordinatorChange}
+                    required
+                    placeholder="Opisz swoje doświadczenie i zadania"
+                />
+            </div>
+        </fieldset>
+    )
+
+    const renderTypeSpecificFields = () => {
+        if (userType === 'organizer') {
+            return renderOrganizerFields()
+        }
+
+        if (userType === 'coordinator') {
+            return renderCoordinatorFields()
+        }
+
+        return renderVolunteerFields()
+    }
+
+    const statusClassName = status.type === 'success'
+        ? `${styles.status} ${styles.statusSuccess}`
+        : status.type === 'error'
+            ? `${styles.status} ${styles.statusError}`
+            : ''
 
     return (
         <section className={styles.page}>
             <div className={styles.formWrapper}>
-                Tu ma być rejestracja
+                <h1 className={styles.title}>Załóż konto</h1>
+                {statusClassName && (
+                    <div className={statusClassName}>{status.message}</div>
+                )}
+                <form className={styles.form} onSubmit={handleSubmit}>
+                    <fieldset className={styles.fieldset}>
+                        <legend className={styles.legend}>Dane logowania</legend>
+                        <div className={styles.fieldGrid}>
+                            <div className={styles.field}>
+                                <label className={styles.label} htmlFor="login">Login</label>
+                                <input
+                                    id="login"
+                                    name="login"
+                                    className={styles.input}
+                                    value={commonData.login}
+                                    onChange={handleCommonChange}
+                                    required
+                                    autoComplete="username"
+                                />
+                            </div>
+                            <div className={styles.field}>
+                                <label className={styles.label} htmlFor="email">Adres e-mail</label>
+                                <input
+                                    id="email"
+                                    name="email"
+                                    className={styles.input}
+                                    type="email"
+                                    value={commonData.email}
+                                    onChange={handleCommonChange}
+                                    required
+                                    autoComplete="email"
+                                />
+                            </div>
+                        </div>
+                        <div className={styles.fieldGrid}>
+                            <div className={styles.field}>
+                                <label className={styles.label} htmlFor="password">Hasło</label>
+                                <input
+                                    id="password"
+                                    name="password"
+                                    className={styles.input}
+                                    type="password"
+                                    value={commonData.password}
+                                    onChange={handleCommonChange}
+                                    required
+                                    autoComplete="new-password"
+                                />
+                            </div>
+                            <div className={styles.field}>
+                                <label className={styles.label} htmlFor="confirmPassword">Powtórz hasło</label>
+                                <input
+                                    id="confirmPassword"
+                                    name="confirmPassword"
+                                    className={styles.input}
+                                    type="password"
+                                    value={commonData.confirmPassword}
+                                    onChange={handleCommonChange}
+                                    required
+                                    autoComplete="new-password"
+                                />
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset className={styles.fieldset}>
+                        <legend className={styles.legend}>Typ konta</legend>
+                        <div className={styles.typeSelection}>
+                            {userTypes.map((option) => (
+                                <label key={option.value} className={styles.radioOption}>
+                                    <input
+                                        type="radio"
+                                        name="userType"
+                                        value={option.value}
+                                        checked={userType === option.value}
+                                        onChange={handleTypeChange}
+                                    />
+                                    {option.label}
+                                </label>
+                            ))}
+                        </div>
+                    </fieldset>
+
+                    {renderTypeSpecificFields()}
+
+                    <div className={styles.actions}>
+                        <button type="submit" className={styles.submit} disabled={isSubmitting}>
+                            {isSubmitting ? 'Zakładanie konta...' : 'Utwórz konto'}
+                        </button>
+                    </div>
+                </form>
             </div>
         </section>
     )

--- a/frontend/src/pages/RegisterPage/RegisterPage.module.scss
+++ b/frontend/src/pages/RegisterPage/RegisterPage.module.scss
@@ -4,28 +4,175 @@
   background: $color-bg;
   border-radius: $border-radius;
   box-shadow: 0 6px 18px rgba($color-primary-mid, 0.08);
-  padding: 1.35rem 1rem;
-  margin-bottom: 1.5rem;
-  max-width: 420px;
+  padding: 1.75rem 2rem;
+  margin-bottom: 2rem;
+  max-width: 760px;
   margin-left: auto;
   margin-right: auto;
 }
 
 .title {
   color: $color-primary-mid;
-  font-size: 1.6rem;
-  margin-bottom: 0.75em;
+  font-size: 1.8rem;
+  margin-bottom: 1.1rem;
 }
 
 .formWrapper {
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 1.35rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.typeSelection {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.radioOption {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: $border-radius;
+  border: 1px solid rgba($color-primary-mid, 0.18);
+  background: rgba($color-primary-mid, 0.05);
+  cursor: pointer;
+  transition: border-color 0.2s, background-color 0.2s;
+
+  input {
+    accent-color: $color-primary-mid;
+  }
+
+  &:hover {
+    border-color: rgba($color-primary-mid, 0.4);
+    background: rgba($color-primary-mid, 0.08);
+  }
+}
+
+.fieldset {
+  border: 1px solid rgba($color-primary-mid, 0.15);
+  border-radius: $border-radius;
+  padding: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+}
+
+.legend {
+  font-weight: 600;
+  color: $color-primary-mid;
+  padding: 0 0.5rem;
+}
+
+.fieldGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.label {
+  font-weight: 600;
+  color: $color-primary-mid;
+}
+
+.input,
+.textarea {
+  width: 100%;
+  border: 1px solid rgba($color-primary-mid, 0.2);
+  border-radius: $border-radius;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.95rem;
+  background: $color-input-bg;
+  transition: border-color 0.2s, box-shadow 0.2s;
+
+  &:focus {
+    border-color: $color-primary-mid;
+    outline: none;
+    box-shadow: $focus-shadow;
+  }
+}
+
+.textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.note {
+  font-size: 0.85rem;
+  color: rgba($color-text, 0.7);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
+.submit {
+  background: linear-gradient(135deg, $color-primary-start, $color-primary-end);
+  border: none;
+  color: $color-bg;
+  font-weight: 600;
+  padding: 0.75rem 1.6rem;
+  border-radius: $border-radius;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+  }
+
+  &:not(:disabled):hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 16px rgba($color-primary-mid, 0.18);
+  }
+}
+
+.status {
+  padding: 0.75rem 1rem;
+  border-radius: $border-radius;
+  font-weight: 600;
+}
+
+.statusSuccess {
+  background: rgba($color-green, 0.12);
+  color: $color-green;
+}
+
+.statusError {
+  background: rgba($color-secondary, 0.12);
+  color: $color-secondary;
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .title {
+    font-size: 1.6rem;
+  }
 }
 
 @media (max-width: 600px) {
   .page {
-    padding: 1.1rem 0.75rem;
+    padding: 1.25rem 0.9rem;
   }
 
   .title {


### PR DESCRIPTION
## Summary
- implement a dynamic registration form that adjusts fields per user type and submits to the API
- extend the backend registration logic to create volunteer, organizer, or coordinator profiles and assign default roles
- introduce the coordinator entity and migration so accounts can link to coordinator records

## Testing
- npm run lint
- dotnet --version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1611cc8648320a92aaa0d742a9fcc