### PR TITLE
Replace auth provider with API login service

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
+import { BrowserRouter, NavLink, Route, Routes, useNavigate } from 'react-router-dom'
 import PublicInfoPage from './pages/PublicInfoPage/PublicInfoPage.jsx'
 import LoginPage from './pages/LoginPage/LoginPage.jsx'
 import RegisterPage from './pages/RegisterPage/RegisterPage.jsx'
@@ -9,19 +9,95 @@ import EventDetailsPage from './pages/EventDetailsPage/EventDetailsPage.jsx'
 import VolunteerPanelPage from './pages/VolunteerPanelPage/VolunteerPanelPage.jsx'
 import MapPage from './pages/MapPage/MapPage.jsx'
 import EventsAndActionsPage from './pages/EventsAndActionsPage/EventsAndActionsPage.jsx'
-const navigationItems = [
-  { to: '/', label: 'Start' },
-  { to: '/login', label: 'Log in' },
-  { to: '/register', label: 'Register' },
-  { to: '/dashboard', label: 'Dashboard' },
-  { to: '/organizer', label: 'Organizer' },
-  { to: '/volunteer', label: 'Volunteer' },
-  { to: '/events-actions', label: 'Wydarzenia i działania' },
-  { to: '/map', label: 'Map' },
-]
+
+const STORAGE_TOKEN_KEY = 'hackyeah2025.auth.token'
+const STORAGE_USER_KEY = 'hackyeah2025.auth.user'
+
+function readStoredAuth() {
+  if (typeof window === 'undefined') {
+    return { token: null, user: null }
+  }
+  try {
+    const token = window.localStorage.getItem(STORAGE_TOKEN_KEY)
+    const userRaw = window.localStorage.getItem(STORAGE_USER_KEY)
+    const user = userRaw ? JSON.parse(userRaw) : null
+    if (typeof token === 'string' && token.length > 0 && user) {
+      return { token, user }
+    }
+  } catch {
+    return { token: null, user: null }
+  }
+  return { token: null, user: null }
+}
+
+function persistAuth(token, user) {
+  if (typeof window === 'undefined') {
+    return
+  }
+  if (token && user) {
+    window.localStorage.setItem(STORAGE_TOKEN_KEY, token)
+    window.localStorage.setItem(STORAGE_USER_KEY, JSON.stringify(user))
+  } else {
+    window.localStorage.removeItem(STORAGE_TOKEN_KEY)
+    window.localStorage.removeItem(STORAGE_USER_KEY)
+  }
+}
 
 export default function App() {
+  const [authState, setAuthState] = useState(() => readStoredAuth())
+
+  useEffect(() => {
+    persistAuth(authState.token, authState.user)
+  }, [authState])
+
+  const handleLogin = (session) => {
+    setAuthState({ token: session.token, user: session.user })
+  }
+
+  const handleLogout = () => {
+    setAuthState({ token: null, user: null })
+  }
+
+  return (
+    <BrowserRouter>
+      <AppLayout authState={authState} onLogin={handleLogin} onLogout={handleLogout} />
+    </BrowserRouter>
+  )
+}
+
+function AppLayout({ authState, onLogin, onLogout }) {
+  const user = authState.user
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const navigate = useNavigate()
+
+  const navigationItems = useMemo(() => {
+    const items = [{ to: '/', label: 'Start' }]
+    const roles = Array.isArray(user?.roles) ? user.roles : []
+
+    if (!user) {
+      items.push({ to: '/login', label: 'Log in' })
+      items.push({ to: '/register', label: 'Register' })
+    }
+
+    if (roles.includes('Administrator') || roles.includes('Koordynator')) {
+      items.push({ to: '/dashboard', label: 'Dashboard' })
+    }
+
+    if (roles.includes('Organizator')) {
+      items.push({ to: '/organizer', label: 'Organizer' })
+    }
+
+    if (roles.includes('Wolontariusz') || roles.includes('Koordynator')) {
+      items.push({ to: '/volunteer', label: 'Volunteer' })
+    }
+
+    items.push(
+      { to: '/events-actions', label: 'Wydarzenia i działania' },
+      { to: '/map', label: 'Map' },
+    )
+
+    return items
+  }, [user])
 
   const toggleMenu = () => {
     setIsMenuOpen((current) => !current)
@@ -31,63 +107,82 @@ export default function App() {
     setIsMenuOpen(false)
   }
 
+  const handleLogoutClick = () => {
+    onLogout()
+    setIsMenuOpen(false)
+    navigate('/', { replace: true })
+  }
+
   return (
-    <BrowserRouter>
-      <div className="app">
-        <header className="header">
-          <img
-            className="brand"
-            src="/assets/mlodzi_dzialaja_logo_small.png"
-            alt="Młodzi działają logo"
-            height={48}
-          />
+    <div className="app">
+      <header className="header">
+        <img
+          className="brand"
+          src="/assets/mlodzi_dzialaja_logo_small.png"
+          alt="Młodzi działają logo"
+          height={48}
+        />
+        <button
+          type="button"
+          className="menu-toggle"
+          aria-expanded={isMenuOpen}
+          onClick={toggleMenu}
+        >
+          ☰
+        </button>
+
+        <nav className={`nav ${isMenuOpen ? 'is-open' : ''}`}>
           <button
             type="button"
             className="menu-toggle"
             aria-expanded={isMenuOpen}
             onClick={toggleMenu}
           >
-            ☰
+            ✕
           </button>
-
-          <nav className={`nav ${isMenuOpen ? 'is-open' : ''}`}>
+          {user ? (
+            <div className="account-chip" aria-live="polite">
+              <span>{user.login}</span>
+              {user.type ? <span>{user.type}</span> : null}
+            </div>
+          ) : null}
+          {navigationItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              onClick={handleNavigation}
+              className={({ isActive }) =>
+                isActive ? 'nav-link active' : 'nav-link'
+              }
+            >
+              {item.label}
+            </NavLink>
+          ))}
+          {user ? (
             <button
               type="button"
-              className="menu-toggle"
-              aria-expanded={isMenuOpen}
-              onClick={toggleMenu}
+              className="nav-link nav-link--button"
+              onClick={handleLogoutClick}
             >
-              ✕
+              Wyloguj
             </button>
-            {navigationItems.map((item) => (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                onClick={handleNavigation}
-                className={({ isActive }) =>
-                  isActive ? 'nav-link active' : 'nav-link'
-                }
-              >
-                {item.label}
-              </NavLink>
-            ))}
-          </nav>
-        </header>
+          ) : null}
+        </nav>
+      </header>
 
-        <main className="content">
-          <Routes>
-            <Route path="/" element={<PublicInfoPage />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/register" element={<RegisterPage />} />
-            <Route path="/dashboard" element={<DashboardPage />} />
-            <Route path="/organizer" element={<OrganizerPanelPage />} />
-            <Route path="/organizer/events/:eventId" element={<EventDetailsPage />} />
-            <Route path="/volunteer" element={<VolunteerPanelPage />} />
-            <Route path="/events-actions" element={<EventsAndActionsPage />} />
-            <Route path="/map" element={<MapPage />} />
-          </Routes>
-        </main>
-      </div>
-    </BrowserRouter>
+      <main className="content">
+        <Routes>
+          <Route path="/" element={<PublicInfoPage />} />
+          <Route path="/login" element={<LoginPage onLogin={onLogin} />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/organizer" element={<OrganizerPanelPage />} />
+          <Route path="/organizer/events/:eventId" element={<EventDetailsPage />} />
+          <Route path="/volunteer" element={<VolunteerPanelPage />} />
+          <Route path="/events-actions" element={<EventsAndActionsPage />} />
+          <Route path="/map" element={<MapPage />} />
+        </Routes>
+      </main>
+    </div>
   )
 }

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,0 +1,170 @@
+const API_URL = '/api/login'
+
+function decodeSegment(segment) {
+  const base64 = segment.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=')
+  const decodeBinary = typeof globalThis.atob === 'function'
+    ? (value) => globalThis.atob(value)
+    : typeof globalThis.Buffer === 'function'
+      ? (value) => globalThis.Buffer.from(value, 'base64').toString('binary')
+      : null
+  if (!decodeBinary) {
+    return null
+  }
+  const binary = decodeBinary(padded)
+  const percentEncoded = Array.from(binary)
+    .map((char) => `%${char.charCodeAt(0).toString(16).padStart(2, '0')}`)
+    .join('')
+  try {
+    const json = decodeURIComponent(percentEncoded)
+    return JSON.parse(json)
+  } catch {
+    return null
+  }
+}
+
+function decodeJwtPayload(token) {
+  if (typeof token !== 'string') {
+    return null
+  }
+  const parts = token.split('.')
+  if (parts.length < 2) {
+    return null
+  }
+  return decodeSegment(parts[1])
+}
+
+function extractRoles(source) {
+  if (!source || typeof source !== 'object') {
+    return []
+  }
+  const candidates = [
+    source.roles,
+    source.Roles,
+    source.role,
+    source.Role,
+  ]
+  const result = []
+  for (const value of candidates) {
+    if (!value) {
+      continue
+    }
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (typeof entry === 'string') {
+          result.push(entry.trim())
+        }
+      }
+      continue
+    }
+    if (typeof value === 'string') {
+      result.push(value.trim())
+    }
+  }
+  return Array.from(new Set(result.filter((value) => value.length > 0)))
+}
+
+function selectUserType(payloadRoles, responseRoles, payload, response) {
+  const roleList = payloadRoles.length > 0 ? payloadRoles : responseRoles
+  if (roleList.length > 0) {
+    const order = ['Administrator', 'Organizator', 'Koordynator', 'Wolontariusz']
+    for (const name of order) {
+      if (roleList.includes(name)) {
+        return name
+      }
+    }
+    return roleList[0]
+  }
+  const typeCandidates = [
+    response?.type,
+    response?.Type,
+    payload?.type,
+    payload?.Type,
+  ]
+  for (const candidate of typeCandidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim()
+    }
+  }
+  return null
+}
+
+function resolveLogin(payload, response, requestedLogin) {
+  const candidates = [
+    response?.login,
+    response?.Login,
+    response?.user?.login,
+    response?.user?.Login,
+    payload?.login,
+    payload?.Login,
+    payload?.sub,
+    payload?.name,
+    requestedLogin,
+  ]
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim()
+    }
+  }
+  return ''
+}
+
+function resolveExpiration(payload, response) {
+  const fromResponse = response?.expiresAt ?? response?.ExpiresAt
+  if (typeof fromResponse === 'string') {
+    const date = new Date(fromResponse)
+    if (!Number.isNaN(date.getTime())) {
+      return date.toISOString()
+    }
+  }
+  const exp = payload?.exp ?? payload?.Exp
+  if (typeof exp === 'number' && Number.isFinite(exp)) {
+    return new Date(exp * 1000).toISOString()
+  }
+  if (typeof exp === 'string' && exp.trim().length > 0) {
+    const value = Number(exp)
+    if (Number.isFinite(value)) {
+      return new Date(value * 1000).toISOString()
+    }
+  }
+  return null
+}
+
+export async function login({ login, password }) {
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ login, password }),
+  })
+  if (response.status === 401 || response.status === 403) {
+    throw new Error('Niepoprawny login lub hasło.')
+  }
+  if (!response.ok) {
+    throw new Error('Nie udało się zalogować.')
+  }
+  const data = await response.json().catch(() => ({}))
+  const token = typeof data === 'object' && data !== null
+    ? data.token ?? data.accessToken ?? data.bearerToken ?? data.jwt
+    : null
+  if (typeof token !== 'string' || token.length === 0) {
+    throw new Error('Brak tokenu w odpowiedzi serwera.')
+  }
+  const payload = decodeJwtPayload(token) ?? {}
+  const payloadRoles = extractRoles(payload)
+  const responseRoles = extractRoles(data)
+  const roles = payloadRoles.length > 0 ? payloadRoles : responseRoles
+  const userType = selectUserType(payloadRoles, responseRoles, payload, data)
+  const loginValue = resolveLogin(payload, data, login)
+  const expiresAt = resolveExpiration(payload, data)
+  return {
+    token,
+    user: {
+      login: loginValue,
+      type: userType,
+      roles,
+      expiresAt,
+    },
+  }
+}

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -1,12 +1,118 @@
+import { useState } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { login as loginRequest } from '../../api/auth.js'
 import styles from './LoginPage.module.scss'
 
-export default function LoginPage() {
+export default function LoginPage({ onLogin }) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [formState, setFormState] = useState({ login: '', password: '' })
+  const [errorMessage, setErrorMessage] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
-    return (
-        <section className={styles.page}>
-            <div className={styles.formWrapper}>
-                Tu ma być logowanie
-            </div>
-        </section>
-    )
+  const handleChange = (event) => {
+    const { name, value } = event.target
+    setFormState((current) => ({
+      ...current,
+      [name]: value,
+    }))
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+
+    const loginValue = formState.login.trim()
+    const passwordValue = formState.password
+
+    if (!loginValue || !passwordValue) {
+      setErrorMessage('Podaj login i hasło.')
+      return
+    }
+
+    setErrorMessage('')
+    setIsSubmitting(true)
+
+    try {
+      const session = await loginRequest({ login: loginValue, password: passwordValue })
+      if (typeof onLogin === 'function') {
+        onLogin(session)
+      }
+      const params = new URLSearchParams(location.search)
+      const redirectTo = params.get('redirectTo') ?? params.get('redirect')
+      const roles = Array.isArray(session.user?.roles) ? session.user.roles : []
+
+      if (redirectTo) {
+        navigate(redirectTo, { replace: true })
+      } else if (roles.includes('Administrator') || roles.includes('Koordynator')) {
+        navigate('/dashboard', { replace: true })
+      } else if (roles.includes('Organizator')) {
+        navigate('/organizer', { replace: true })
+      } else if (roles.includes('Wolontariusz')) {
+        navigate('/volunteer', { replace: true })
+      } else {
+        navigate('/', { replace: true })
+      }
+
+      setFormState({ login: '', password: '' })
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Nie udało się zalogować.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <section className={styles.page}>
+      <div className={styles.formWrapper}>
+        <h1 className={styles.title}>Logowanie</h1>
+        <p className={styles.subtitle}>
+          Uzyskaj dostęp do panelu wolontariusza lub organizatora. Po zalogowaniu przypiszemy Ci właściwy typ konta na podstawie tokenu.
+        </p>
+        {errorMessage ? <div className={styles.errorMessage}>{errorMessage}</div> : null}
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+          <label htmlFor="login">
+            Login
+            <input
+              id="login"
+              name="login"
+              type="text"
+              autoComplete="username"
+              className="form-controller"
+              placeholder="Wpisz login"
+              value={formState.login}
+              onChange={handleChange}
+              disabled={isSubmitting}
+              required
+            />
+          </label>
+          <label htmlFor="password">
+            Hasło
+            <input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              className="form-controller"
+              placeholder="Wpisz hasło"
+              value={formState.password}
+              onChange={handleChange}
+              disabled={isSubmitting}
+              required
+            />
+          </label>
+          <div className={styles.actions}>
+            <button type="submit" className="btn btn-primary" disabled={isSubmitting}>
+              {isSubmitting ? 'Logowanie...' : 'Zaloguj się'}
+            </button>
+          </div>
+        </form>
+        <p className={styles.helperText}>
+          Nie masz konta?{' '}
+          <Link className={styles.helperLink} to="/register">
+            Zarejestruj się
+          </Link>
+        </p>
+      </div>
+    </section>
+  )
 }

--- a/frontend/src/pages/LoginPage/LoginPage.module.scss
+++ b/frontend/src/pages/LoginPage/LoginPage.module.scss
@@ -23,6 +23,44 @@
   gap: 0.9rem;
 }
 
+.subtitle {
+  color: rgba($color-text, 0.85);
+  margin: 0 0 0.6rem 0;
+  line-height: 1.45;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: 0.35rem;
+}
+
+.errorMessage {
+  background: rgba($color-secondary, 0.12);
+  border-radius: $border-radius;
+  color: $color-secondary;
+  font-weight: 600;
+  padding: 0.6rem 0.85rem;
+}
+
+.helperText {
+  margin-top: 0.75rem;
+  color: rgba($color-text, 0.8);
+}
+
+.helperLink {
+  color: $color-primary-mid;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
 @media (max-width: 600px) {
   .page {
     padding: 1.1rem 0.75rem;


### PR DESCRIPTION
## Summary
- remove the React auth context in favor of local state managed in App with storage persistence
- add a dedicated frontend API service for /api/login that extracts token metadata and user roles
- update the login page to use the API service and notify App so navigation reacts to the authenticated user

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e16350da148320b0cdf003fb619edb