### PR TITLE
Expose backend base URL for frontend API calls

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,10 +14,12 @@ Interfejs został przygotowany w oparciu o Vite i React. Aplikacja integruje si�
    ```bash
    npm install
    ```
-2. Ustaw zmienną środowiskową z adresem SDK Ory (domyślnie `http://localhost:4000` – taki adres wystawia tunel Ory):
+2. Ustaw zmienne środowiskowe z adresami usług backendowych:
    ```bash
+   export VITE_API_BASE_URL="http://localhost:7258/api"
    export VITE_ORY_SDK_URL="http://localhost:4000"
    ```
+   Pierwsza zmienna wskazuje adres backendu aplikacji, druga adres SDK Ory (domyślnie `http://localhost:4000`, który udostępnia tunel Ory).
 3. Uruchom tunel wskazując adres aplikacji (domyślnie `http://localhost:5173`):
    ```bash
    ory tunnel --project <ID_PROJEKTU> http://localhost:5173

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,0 +1,15 @@
+import { apiRequest } from './client'
+
+export async function registerUser(payload) {
+    const response = await apiRequest('/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+        const errorBody = await response.json().catch(() => null)
+        const message = errorBody?.error ?? 'Wystąpił błąd podczas rejestracji.'
+        throw new Error(message)
+    }
+}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,0 +1,11 @@
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '/api').replace(/\/$/, '')
+
+function buildUrl(path) {
+    const sanitizedPath = path.startsWith('/') ? path : `/${path}`
+    return `${API_BASE_URL}${sanitizedPath}`
+}
+
+export async function apiRequest(path, options = {}) {
+    const response = await fetch(buildUrl(path), options)
+    return response
+}

--- a/frontend/src/pages/RegisterPage/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { registerUser } from '../../api/auth'
 import styles from './RegisterPage.module.scss'
 
 const userTypes = [
@@ -142,18 +143,7 @@ export default function RegisterPage() {
         const payload = buildRegisterPayload(userType, commonData, volunteerData, organizerData, coordinatorData)
 
         try {
-            const response = await fetch('/api/auth/register', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload)
-            })
-
-            if (!response.ok) {
-                const errorBody = await response.json().catch(() => null)
-                const errorMessage = errorBody?.error ?? 'Wystąpił błąd podczas rejestracji.'
-                throw new Error(errorMessage)
-            }
-
+            await registerUser(payload)
             setStatus({ type: 'success', message: 'Konto zostało utworzone. Możesz się teraz zalogować.' })
         } catch (error) {
             setStatus({ type: 'error', message: error.message || 'Wystąpił błąd podczas rejestracji.' })


### PR DESCRIPTION
## Summary
- read the backend base URL for API calls from the VITE_API_BASE_URL environment variable
- centralize HTTP communication in a dedicated src/api layer and reuse it for user registration
- document the new backend configuration variable in the frontend README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e16b10f448832091f598f2e6c0aede