### PR TITLE
Fix dev proxy target to HTTPS backend

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:7258',
+        target: 'https://localhost:7258',
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path.replace(/^\/api/, '/api'),


### PR DESCRIPTION
## Summary
- point the Vite dev proxy at the HTTPS backend port so API calls succeed during local development

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e16dd4d2ac8320975cf01f2b432e74