### PR TITLE
Add login page with JWT authentication handling

### DIFF
--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -13,3 +13,20 @@ export async function registerUser(payload) {
         throw new Error(message)
     }
 }
+
+export async function loginUser(credentials) {
+    const response = await apiRequest('/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(credentials),
+    })
+
+    const responseBody = await response.json().catch(() => null)
+
+    if (!response.ok) {
+        const message = responseBody?.error ?? 'Nie udało się zalogować.'
+        throw new Error(message)
+    }
+
+    return responseBody
+}

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -1,11 +1,123 @@
+import { useState } from 'react'
+import { loginUser } from '../../api/auth'
 import styles from './LoginPage.module.scss'
 
+const defaultFormData = {
+    login: '',
+    password: '',
+}
+
 export default function LoginPage() {
+    const [formData, setFormData] = useState(defaultFormData)
+    const [status, setStatus] = useState({ type: '', message: '' })
+    const [isSubmitting, setIsSubmitting] = useState(false)
+
+    const handleChange = (event) => {
+        const { name, value } = event.target
+        setFormData((prev) => ({ ...prev, [name]: value }))
+    }
+
+    const handleSubmit = async (event) => {
+        event.preventDefault()
+        setIsSubmitting(true)
+        setStatus({ type: '', message: '' })
+
+        try {
+            const payload = {
+                login: formData.login.trim(),
+                password: formData.password,
+            }
+
+            const authResponse = await loginUser(payload)
+
+            if (!authResponse?.token) {
+                throw new Error('Nie otrzymano tokenu uwierzytelniającego.')
+            }
+
+            if (authResponse?.accountId) {
+                localStorage.setItem('authAccountId', authResponse.accountId)
+            }
+
+            if (authResponse?.token) {
+                localStorage.setItem('authToken', authResponse.token)
+            }
+
+            if (authResponse?.expiresAt) {
+                localStorage.setItem('authTokenExpiresAt', authResponse.expiresAt)
+            }
+
+            if (authResponse?.login) {
+                localStorage.setItem('authLogin', authResponse.login)
+            }
+
+            if (authResponse?.roles) {
+                localStorage.setItem('authRoles', JSON.stringify(authResponse.roles))
+            }
+
+            setStatus({ type: 'success', message: 'Zalogowano pomyślnie.' })
+            setFormData(defaultFormData)
+        } catch (error) {
+            setStatus({ type: 'error', message: error.message || 'Nie udało się zalogować.' })
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    const statusClassNames = [styles.status]
+
+    if (status.type === 'success') {
+        statusClassNames.push(styles.statusSuccess)
+    }
+
+    if (status.type === 'error') {
+        statusClassNames.push(styles.statusError)
+    }
 
     return (
         <section className={styles.page}>
             <div className={styles.formWrapper}>
-                Tu ma być logowanie
+                <h1 className={styles.title}>Zaloguj się</h1>
+
+                {status.message && (
+                    <div className={statusClassNames.join(' ')}>{status.message}</div>
+                )}
+
+                <form className={styles.form} onSubmit={handleSubmit}>
+                    <div className={styles.field}>
+                        <label className={styles.label} htmlFor="login">Login</label>
+                        <input
+                            id="login"
+                            name="login"
+                            className={styles.input}
+                            value={formData.login}
+                            onChange={handleChange}
+                            required
+                            autoComplete="username"
+                            disabled={isSubmitting}
+                        />
+                    </div>
+
+                    <div className={styles.field}>
+                        <label className={styles.label} htmlFor="password">Hasło</label>
+                        <input
+                            id="password"
+                            name="password"
+                            type="password"
+                            className={styles.input}
+                            value={formData.password}
+                            onChange={handleChange}
+                            required
+                            autoComplete="current-password"
+                            disabled={isSubmitting}
+                        />
+                    </div>
+
+                    <div className={styles.actions}>
+                        <button className={styles.submit} type="submit" disabled={isSubmitting}>
+                            {isSubmitting ? 'Logowanie...' : 'Zaloguj się'}
+                        </button>
+                    </div>
+                </form>
             </div>
         </section>
     )

--- a/frontend/src/pages/LoginPage/LoginPage.module.scss
+++ b/frontend/src/pages/LoginPage/LoginPage.module.scss
@@ -23,6 +23,87 @@
   gap: 0.9rem;
 }
 
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.label {
+  font-weight: 600;
+  color: $color-primary-mid;
+}
+
+.input {
+  width: 100%;
+  border: 1px solid rgba($color-primary-mid, 0.2);
+  border-radius: $border-radius;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.95rem;
+  background: $color-input-bg;
+  transition: border-color 0.2s, box-shadow 0.2s;
+
+  &:focus {
+    border-color: $color-primary-mid;
+    outline: none;
+    box-shadow: $focus-shadow;
+  }
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.submit {
+  background: linear-gradient(135deg, $color-primary-start, $color-primary-end);
+  border: none;
+  color: $color-bg;
+  font-weight: 600;
+  padding: 0.7rem 1.4rem;
+  border-radius: $border-radius;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+  }
+
+  &:not(:disabled):hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba($color-primary-mid, 0.18);
+  }
+}
+
+.status {
+  padding: 0.7rem 0.9rem;
+  border-radius: $border-radius;
+  font-weight: 600;
+}
+
+.statusSuccess {
+  background: rgba($color-green, 0.12);
+  color: $color-green;
+}
+
+.statusError {
+  background: rgba($color-secondary, 0.12);
+  color: $color-secondary;
+}
+
 @media (max-width: 600px) {
   .page {
     padding: 1.1rem 0.75rem;


### PR DESCRIPTION
## Summary
- add frontend API client helper to perform login and retrieve JWT payload
- build login page with form submission, success and error handling, and token persistence
- style the login view to match existing design system

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e172102e2c832099ad939a8e932965