### PR TITLE
Surface account type during auth and add coordinator area

### DIFF
--- a/backend/HackYeah2025.Backend/HackYeah2025/Features/Auth/AuthContracts.cs
+++ b/backend/HackYeah2025.Backend/HackYeah2025/Features/Auth/AuthContracts.cs
@@ -156,4 +156,5 @@ public record AuthResponse
     public required string Login { get; init; }
     public required string Email { get; init; }
     public required IReadOnlyCollection<string> Roles { get; init; }
+    public required string AccountType { get; init; }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import EventDetailsPage from './pages/EventDetailsPage/EventDetailsPage.jsx'
 import VolunteerPanelPage from './pages/VolunteerPanelPage/VolunteerPanelPage.jsx'
 import MapPage from './pages/MapPage/MapPage.jsx'
 import EventsAndActionsPage from './pages/EventsAndActionsPage/EventsAndActionsPage.jsx'
+import CoordinatorProfilePage from './pages/CoordinatorProfilePage/CoordinatorProfilePage.jsx'
 import PublicLayout from './layouts/PublicLayout/PublicLayout.jsx'
 import MainLayout from './layouts/MainLayout/MainLayout.jsx'
 
@@ -29,6 +30,7 @@ export default function App() {
           <Route path="/volunteer" element={<VolunteerPanelPage />} />
           <Route path="/events-actions" element={<EventsAndActionsPage />} />
           <Route path="/map" element={<MapPage />} />
+          <Route path="/coordinator" element={<CoordinatorProfilePage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -7,11 +7,14 @@ export async function registerUser(payload) {
         body: JSON.stringify(payload),
     })
 
+    const responseBody = await response.json().catch(() => null)
+
     if (!response.ok) {
-        const errorBody = await response.json().catch(() => null)
-        const message = errorBody?.error ?? 'Wystąpił błąd podczas rejestracji.'
+        const message = responseBody?.error ?? 'Wystąpił błąd podczas rejestracji.'
         throw new Error(message)
     }
+
+    return responseBody
 }
 
 export async function loginUser(credentials) {

--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -6,6 +6,7 @@ const navigationItems = [
     { to: '/organizer', label: 'Organizer' },
     { to: '/volunteer', label: 'Volunteer' },
     { to: '/events-actions', label: 'Wydarzenia i działania' },
+    { to: '/coordinator', label: 'Coordinator' },
     { to: '/map', label: 'Map' },
 ]
 

--- a/frontend/src/pages/CoordinatorProfilePage/CoordinatorProfilePage.jsx
+++ b/frontend/src/pages/CoordinatorProfilePage/CoordinatorProfilePage.jsx
@@ -1,0 +1,121 @@
+import styles from './CoordinatorProfilePage.module.scss'
+
+const metrics = [
+    { label: 'Aktywne inicjatywy', value: '8', description: 'Wolontariusze przypisani w tym tygodniu' },
+    { label: 'Zespoły w koordynacji', value: '5', description: 'W tym dwa interdyscyplinarne' },
+    { label: 'Średni czas reakcji', value: '2 h', description: 'Na zgłoszenia wolontariuszy' },
+]
+
+const upcomingMeetings = [
+    { id: 1, title: 'Spotkanie zespołu mobilnego', date: '13 stycznia 2025', time: '09:30', location: 'Centrum Obywatelskie' },
+    { id: 2, title: 'Warsztat onboardingowy', date: '15 stycznia 2025', time: '17:00', location: 'Online' },
+    { id: 3, title: 'Debriefing po wydarzeniu', date: '19 stycznia 2025', time: '11:00', location: 'Fundacja Razem' },
+]
+
+const focusAreas = [
+    'Budowanie partnerstw lokalnych',
+    'Wsparcie wolontariuszy pierwszej linii',
+    'Standaryzacja procedur bezpieczeństwa',
+    'Monitorowanie wskaźników jakości',
+]
+
+const teamMembers = [
+    { id: 1, name: 'Katarzyna Mazur', role: 'Specjalistka ds. wolontariatu', availability: 'Poniedziałek – czwartek' },
+    { id: 2, name: 'Michał Wójcik', role: 'Koordynator logistyki', availability: 'Wtorek – sobota' },
+    { id: 3, name: 'Ola Zielińska', role: 'Mentorka', availability: 'Elastycznie' },
+]
+
+export default function CoordinatorProfilePage() {
+    return (
+        <section className={styles.page}>
+            <header className={styles.hero}>
+                <div>
+                    <span className={styles.role}>Koordynatorka</span>
+                    <h1 className={styles.name}>Anna Kowalczyk</h1>
+                    <p className={styles.description}>
+                        Odpowiadam za rozwój programów wolontariackich w Krakowie i regionie. Wspieram zespoły w planowaniu
+                        działań, dbam o przepływ informacji i jakość doświadczeń wolontariuszy.
+                    </p>
+                </div>
+                <div className={styles.actions}>
+                    <button type="button" className={styles.primaryAction}>Utwórz nowe wydarzenie</button>
+                    <button type="button" className={styles.secondaryAction}>Zobacz raport miesięczny</button>
+                </div>
+            </header>
+
+            <section className={styles.metrics}>
+                {metrics.map((item) => (
+                    <article key={item.label} className={styles.metric}>
+                        <span className={styles.metricValue}>{item.value}</span>
+                        <span className={styles.metricLabel}>{item.label}</span>
+                        <p className={styles.metricDescription}>{item.description}</p>
+                    </article>
+                ))}
+            </section>
+
+            <div className={styles.columns}>
+                <div className={styles.mainColumn}>
+                    <section className={styles.card}>
+                        <h2>Najbliższe spotkania</h2>
+                        <ul className={styles.meetingList}>
+                            {upcomingMeetings.map((meeting) => (
+                                <li key={meeting.id} className={styles.meetingItem}>
+                                    <div>
+                                        <h3>{meeting.title}</h3>
+                                        <p className={styles.meetingMeta}>
+                                            <span>{meeting.date}</span>
+                                            <span>{meeting.time}</span>
+                                            <span>{meeting.location}</span>
+                                        </p>
+                                    </div>
+                                    <button type="button" className={styles.meetingAction}>Przypisz wolontariuszy</button>
+                                </li>
+                            ))}
+                        </ul>
+                    </section>
+
+                    <section className={styles.card}>
+                        <h2>Priorytetowe obszary</h2>
+                        <ul className={styles.tagList}>
+                            {focusAreas.map((area) => (
+                                <li key={area} className={styles.tag}>{area}</li>
+                            ))}
+                        </ul>
+                    </section>
+                </div>
+
+                <aside className={styles.sideColumn}>
+                    <section className={styles.card}>
+                        <h2>Zespół wsparcia</h2>
+                        <ul className={styles.teamList}>
+                            {teamMembers.map((member) => (
+                                <li key={member.id} className={styles.teamMember}>
+                                    <div>
+                                        <h3>{member.name}</h3>
+                                        <p className={styles.teamRole}>{member.role}</p>
+                                    </div>
+                                    <span className={styles.teamAvailability}>{member.availability}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </section>
+
+                    <section className={styles.card}>
+                        <h2>Materiały dla wolontariuszy</h2>
+                        <ul className={styles.resources}>
+                            <li>
+                                <a href="#">Standard komunikacji kryzysowej</a>
+                            </li>
+                            <li>
+                                <a href="#">Checklisty przed wydarzeniem</a>
+                            </li>
+                            <li>
+                                <a href="#">Plan rozwoju kompetencji</a>
+                            </li>
+                        </ul>
+                    </section>
+                </aside>
+            </div>
+        </section>
+    )
+}

--- a/frontend/src/pages/CoordinatorProfilePage/CoordinatorProfilePage.module.scss
+++ b/frontend/src/pages/CoordinatorProfilePage/CoordinatorProfilePage.module.scss
@@ -1,0 +1,278 @@
+.page {
+    min-height: 100%;
+    padding: clamp(1.5rem, 2vw + 1rem, 3rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.5rem, 2vw + 1rem, 3rem);
+    background: #f8fafc;
+    color: #0f172a;
+}
+
+.hero {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(56, 189, 248, 0.12));
+    border-radius: 24px;
+    padding: clamp(1.75rem, 2.5vw + 1rem, 3rem);
+}
+
+.role {
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #1d4ed8;
+    font-weight: 600;
+}
+
+.name {
+    font-size: clamp(2rem, 3vw + 1rem, 3rem);
+    margin: 0.25rem 0 0.75rem;
+    font-weight: 700;
+}
+
+.description {
+    max-width: 56ch;
+    line-height: 1.6;
+    color: #1e293b;
+}
+
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.primaryAction,
+.secondaryAction {
+    border: none;
+    border-radius: 999px;
+    padding: 0.75rem 1.5rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.primaryAction {
+    background: #1d4ed8;
+    color: #ffffff;
+    box-shadow: 0 10px 30px rgba(29, 78, 216, 0.25);
+}
+
+.primaryAction:hover,
+.primaryAction:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 32px rgba(29, 78, 216, 0.3);
+}
+
+.secondaryAction {
+    background: rgba(29, 78, 216, 0.1);
+    color: #1d4ed8;
+}
+
+.secondaryAction:hover,
+.secondaryAction:focus-visible {
+    transform: translateY(-1px);
+    background: rgba(29, 78, 216, 0.15);
+}
+
+.metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.metric {
+    background: #ffffff;
+    border-radius: 20px;
+    padding: clamp(1.25rem, 2vw + 0.5rem, 1.75rem);
+    box-shadow: 0 12px 40px rgba(15, 23, 42, 0.06);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.metricValue {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.metricLabel {
+    font-weight: 600;
+    color: #1d4ed8;
+}
+
+.metricDescription {
+    margin: 0;
+    color: #475569;
+}
+
+.columns {
+    display: grid;
+    grid-template-columns: minmax(0, 2.5fr) minmax(0, 1fr);
+    gap: clamp(1.5rem, 2.5vw, 2.5rem);
+}
+
+.mainColumn,
+.sideColumn {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.25rem, 2vw, 1.75rem);
+}
+
+.card {
+    background: #ffffff;
+    border-radius: 24px;
+    padding: clamp(1.5rem, 2vw + 0.75rem, 2rem);
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+}
+
+.card > h2 {
+    margin-bottom: 1rem;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.meetingList,
+.tagList,
+.teamList,
+.resources {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.meetingItem {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem;
+    border-radius: 16px;
+    background: #f1f5f9;
+}
+
+.meetingItem h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1.125rem;
+}
+
+.meetingMeta {
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    color: #475569;
+    font-size: 0.95rem;
+}
+
+.meetingAction {
+    align-self: flex-start;
+    border: none;
+    border-radius: 12px;
+    padding: 0.6rem 1.2rem;
+    background: #1d4ed8;
+    color: #ffffff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.meetingAction:hover,
+.meetingAction:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 25px rgba(29, 78, 216, 0.2);
+}
+
+.tagList {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.tag {
+    padding: 0.5rem 1.25rem;
+    border-radius: 999px;
+    background: rgba(29, 78, 216, 0.12);
+    color: #1d4ed8;
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.teamMember {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: 16px;
+    background: #f8fafc;
+}
+
+.teamMember h3 {
+    margin: 0 0 0.3rem;
+    font-size: 1.05rem;
+}
+
+.teamRole {
+    margin: 0;
+    color: #475569;
+    font-size: 0.95rem;
+}
+
+.teamAvailability {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #1d4ed8;
+}
+
+.resources a {
+    color: #1d4ed8;
+    font-weight: 600;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.resources a::after {
+    content: '→';
+    font-size: 1rem;
+}
+
+.resources a:hover,
+.resources a:focus-visible {
+    text-decoration: underline;
+}
+
+@media (max-width: 1024px) {
+    .columns {
+        grid-template-columns: 1fr;
+    }
+
+    .hero {
+        flex-direction: column;
+    }
+
+    .actions {
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 640px) {
+    .hero {
+        padding: 1.5rem;
+    }
+
+    .metricValue {
+        font-size: 1.75rem;
+    }
+
+    .meetingItem {
+        padding: 0.85rem;
+    }
+}

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { loginUser } from '../../api/auth'
 import styles from './LoginPage.module.scss'
 
@@ -11,6 +12,25 @@ export default function LoginPage() {
     const [formData, setFormData] = useState(defaultFormData)
     const [status, setStatus] = useState({ type: '', message: '' })
     const [isSubmitting, setIsSubmitting] = useState(false)
+    const navigate = useNavigate()
+
+    const resolveDestination = (accountType) => {
+        if (!accountType) {
+            return '/events-actions'
+        }
+
+        const normalizedType = accountType.toLowerCase()
+
+        if (normalizedType === 'organizer') {
+            return '/organizer'
+        }
+
+        if (normalizedType === 'coordinator') {
+            return '/coordinator'
+        }
+
+        return '/events-actions'
+    }
 
     const handleChange = (event) => {
         const { name, value } = event.target
@@ -56,6 +76,14 @@ export default function LoginPage() {
 
             setStatus({ type: 'success', message: 'Zalogowano pomyślnie.' })
             setFormData(defaultFormData)
+
+            if (authResponse?.accountType) {
+                localStorage.setItem('authAccountType', authResponse.accountType)
+            }
+
+            const destination = resolveDestination(authResponse?.accountType)
+
+            navigate(destination, { replace: true })
         } catch (error) {
             setStatus({ type: 'error', message: error.message || 'Nie udało się zalogować.' })
         } finally {


### PR DESCRIPTION
## Summary
- include the resolved account type in authentication responses and JWT claims
- persist account type on the frontend and redirect users to role-specific dashboards after login or registration
- add a coordinator profile route with navigation entry and dedicated layout

## Testing
- npm run build
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e175da410c8320b713b0046ceeb958