### PR TITLE
Ulepsz selektor typu konta w panelu rejestracji

### DIFF
--- a/frontend/src/pages/RegisterPage/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.jsx
@@ -3,9 +3,9 @@ import { registerUser } from '../../api/auth'
 import styles from './RegisterPage.module.scss'
 
 const userTypes = [
-    { value: 'volunteer', label: 'Wolontariusz' },
-    { value: 'organizer', label: 'Organizator' },
-    { value: 'coordinator', label: 'Koordynator' }
+    { value: 'volunteer', label: 'Wolontariusz', description: 'Chcę pomagać podczas wydarzeń i akcji.' },
+    { value: 'organizer', label: 'Organizator', description: 'Reprezentuję instytucję i tworzę wydarzenia.' },
+    { value: 'coordinator', label: 'Koordynator', description: 'Łączę zespoły i pilnuję przebiegu działań.' }
 ]
 
 const defaultVolunteerData = {
@@ -544,15 +544,22 @@ export default function RegisterPage() {
                         <legend className={styles.legend}>Typ konta</legend>
                         <div className={styles.typeSelection}>
                             {userTypes.map((option) => (
-                                <label key={option.value} className={styles.radioOption}>
+                                <label
+                                    key={option.value}
+                                    className={`${styles.radioOption} ${userType === option.value ? styles.radioOptionActive : ''}`.trim()}
+                                >
                                     <input
                                         type="radio"
                                         name="userType"
                                         value={option.value}
                                         checked={userType === option.value}
                                         onChange={handleTypeChange}
+                                        className={styles.radioInput}
                                     />
-                                    {option.label}
+                                    <span className={styles.radioContent}>
+                                        <span className={styles.radioLabel}>{option.label}</span>
+                                        <span className={styles.radioDescription}>{option.description}</span>
+                                    </span>
                                 </label>
                             ))}
                         </div>

--- a/frontend/src/pages/RegisterPage/RegisterPage.module.scss
+++ b/frontend/src/pages/RegisterPage/RegisterPage.module.scss
@@ -30,30 +30,65 @@
 }
 
 .typeSelection {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 .radioOption {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.55rem 0.85rem;
-  border-radius: $border-radius;
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  border-radius: calc($border-radius * 1.1);
   border: 1px solid rgba($color-primary-mid, 0.18);
-  background: rgba($color-primary-mid, 0.05);
+  background: linear-gradient(135deg, rgba($color-primary-mid, 0.04), rgba($color-primary-mid, 0.08));
   cursor: pointer;
-  transition: border-color 0.2s, background-color 0.2s;
-
-  input {
-    accent-color: $color-primary-mid;
-  }
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
 
   &:hover {
-    border-color: rgba($color-primary-mid, 0.4);
-    background: rgba($color-primary-mid, 0.08);
+    border-color: rgba($color-primary-mid, 0.35);
+    box-shadow: 0 8px 18px rgba($color-primary-mid, 0.12);
+    transform: translateY(-1px);
   }
+
+  &:focus-within {
+    border-color: $color-primary-mid;
+    box-shadow: 0 0 0 4px rgba($color-primary-mid, 0.15);
+  }
+}
+
+.radioOptionActive {
+  border-color: $color-primary-mid;
+  background: linear-gradient(140deg, rgba($color-primary-start, 0.22), rgba($color-primary-end, 0.16));
+  box-shadow: 0 10px 22px rgba($color-primary-mid, 0.18);
+}
+
+.radioInput {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.radioContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.9rem 1rem;
+  width: 100%;
+}
+
+.radioLabel {
+  font-weight: 700;
+  color: $color-primary-mid;
+  font-size: 1.05rem;
+}
+
+.radioDescription {
+  font-size: 0.9rem;
+  line-height: 1.35;
+  color: rgba($color-text, 0.72);
 }
 
 .fieldset {


### PR DESCRIPTION
## Podsumowanie
- dodano opisy do dostępnych typów kont na ekranie rejestracji
- przeprojektowano selektor typu konta na karty podkreślające aktywną opcję

## Testy
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e177b1e6d08320b7cb6d6df6ca5ced