### PR TITLE
Translate frontend navigation to Polish

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="pl">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -2,12 +2,12 @@ import { NavLink } from 'react-router-dom'
 import styles from './Header.module.scss'
 
 const navigationItems = [
-    { to: '/dashboard', label: 'Dashboard' },
-    { to: '/organizer', label: 'Organizer' },
-    { to: '/volunteer', label: 'Volunteer' },
+    { to: '/dashboard', label: 'Panel główny' },
+    { to: '/organizer', label: 'Panel organizatora' },
+    { to: '/volunteer', label: 'Panel wolontariusza' },
     { to: '/events-actions', label: 'Wydarzenia i działania' },
-    { to: '/coordinator', label: 'Coordinator' },
-    { to: '/map', label: 'Map' },
+    { to: '/coordinator', label: 'Koordynator' },
+    { to: '/map', label: 'Mapa' },
 ]
 
 export default function Header() {

--- a/frontend/src/pages/DashboardPage/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage/DashboardPage.jsx
@@ -4,8 +4,8 @@ export default function DashboardPage() {
 
     return (
         <section className={styles.page}>
-            <h1 className={styles.title}>Dashboard</h1>
-            <p className={styles.description}>Track your registrations, team updates, and event announcements.</p>
+            <h1 className={styles.title}>Panel główny</h1>
+            <p className={styles.description}>Monitoruj swoje zgłoszenia, aktualizacje zespołu i ogłoszenia wydarzeń.</p>
 
             <div className="card">
                 Tu ma być dashboard

--- a/frontend/src/pages/MapPage/MapPage.jsx
+++ b/frontend/src/pages/MapPage/MapPage.jsx
@@ -15,7 +15,7 @@ const markerIcon = new L.Icon({
 export default function MapPage() {
     return (
         <section className={styles.page}>
-            <h1>Event map</h1>
+            <h1>Mapa wydarzeń</h1>
             <div className={styles['map-wrapper']}>
                 <MapContainer center={[49.9737, 20.0470]} zoom={8} scrollWheelZoom className={styles.map}>
                     <TileLayer
@@ -23,7 +23,7 @@ export default function MapPage() {
                         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                     />
                     <Marker position={[49.9737, 20.0470]} icon={markerIcon}>
-                        <Popup>Małopolskie region</Popup>
+                        <Popup>Region Małopolski</Popup>
                     </Marker>
                 </MapContainer>
             </div>


### PR DESCRIPTION
## Summary
- update nagłówek dokumentu i atrybut języka dla aplikacji frontendowej
- przetłumacz nawigację, panel główny oraz mapę wydarzeń na język polski

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e17985d2748320b1eb53ec42f4d3c2